### PR TITLE
cargo-bpf: fix ctrl-c handling

### DIFF
--- a/cargo-bpf/src/load.rs
+++ b/cargo-bpf/src/load.rs
@@ -10,35 +10,38 @@ use redbpf::{Module, PerfMap};
 use std::fs;
 use std::path::PathBuf;
 use tokio;
+use tokio::runtime::Runtime;
 use tokio_signal::ctrl_c;
 use std::ffi::CString;
 use bpf_sys;
 
 pub fn load(program: &PathBuf, interface: Option<&str>) -> Result<(), CommandError> {
     let data = fs::read(program)?;
-    let mut module = Module::parse(&data).expect("failed to parse ELF data");
-    for prog in module.programs.iter_mut() {
-        prog.load(module.version, module.license.clone())
-            .expect("failed to load program");
-    }
-
-    if let Some(interface) = interface {
-        for prog in module.programs.iter_mut().filter(|p| p.kind == XDP) {
-            println!("Loaded: {}, {:?}", prog.name, prog.kind);
-            prog.attach_xdp(interface).unwrap();
+    let iface = interface.map(String::from);
+    let mut runtime = Runtime::new().unwrap();
+    runtime.block_on(futures::lazy(move || {
+        let mut module = Module::parse(&data).expect("failed to parse ELF data");
+        for prog in module.programs.iter_mut() {
+            prog.load(module.version, module.license.clone())
+                .expect("failed to load program");
         }
-    }
 
-    for prog in module
-        .programs
-        .iter_mut()
-        .filter(|p| p.kind == Kprobe || p.kind == Kretprobe)
-    {
-        prog.attach_probe()
-            .expect(&format!("Failed to attach kprobe {}", prog.name));
-        println!("Loaded: {}, {:?}", prog.name, prog.kind);
-    }
-    tokio::run(futures::lazy(move || {
+        if let Some(interface) = iface {
+            for prog in module.programs.iter_mut().filter(|p| p.kind == XDP) {
+                println!("Loaded: {}, {:?}", prog.name, prog.kind);
+                prog.attach_xdp(&interface).unwrap();
+            }
+        }
+
+        for prog in module
+            .programs
+            .iter_mut()
+            .filter(|p| p.kind == Kprobe || p.kind == Kretprobe)
+        {
+            prog.attach_probe()
+                .expect(&format!("Failed to attach kprobe {}", prog.name));
+            println!("Loaded: {}, {:?}", prog.name, prog.kind);
+        }
         let online_cpus = cpus::get_online().unwrap();
         for m in module.maps.iter_mut().filter(|m| m.kind == 4) {
             for cpuid in online_cpus.iter() {
@@ -58,7 +61,9 @@ pub fn load(program: &PathBuf, interface: Option<&str>) -> Result<(), CommandErr
         }
 
         ctrl_c().flatten_stream().take(1).into_future().map(|_| ()).map_err(|_| ())
-    }));
+    })).unwrap();
+
+    println!("exiting");
 
     if let Some(interface) = interface {
         let ciface = CString::new(interface).unwrap();


### PR DESCRIPTION
Call runtime.block_on() instead of tokio::run() as the latter will wait
for background tasks to complete (which is never).