### PR TITLE
cargo-bpf: probes don't need const_{transmute|fn} anymore

### DIFF
--- a/cargo-bpf/src/new.rs
+++ b/cargo-bpf/src/new.rs
@@ -45,7 +45,6 @@ path = "src/lib.rs"
     write!(
         &mut file,
         r#"
-#![feature(const_fn, const_transmute)]
 #![no_std]
 "#
     )?;


### PR DESCRIPTION
As per subject. We can now compile on stable so remove unstable features we don't need anymore.