### PR TITLE
redbpf-macros: generate memory builtins in probe!()

### DIFF
--- a/redbpf-macros/src/lib.rs
+++ b/redbpf-macros/src/lib.rs
@@ -43,11 +43,12 @@ extern crate proc_macro2;
 use proc_macro::TokenStream;
 use proc_macro2::{Ident, Span, TokenStream as TokenStream2};
 use quote::quote;
+use std::str;
 use syn::parse::{Parse, ParseStream};
 use syn::punctuated::Punctuated;
 use syn::token::Comma;
 use syn::{
-    parse_macro_input, parse_quote, parse_str, Block, Expr, ExprLit, FnArg, ItemFn, Lit, Pat,
+    parse_macro_input, parse_quote, parse_str, Block, Expr, ExprLit, File, FnArg, ItemFn, Lit, Pat,
     PatIdent, PatType, Result, Stmt,
 };
 
@@ -104,6 +105,12 @@ pub fn program(input: TokenStream) -> TokenStream {
         pub static _version: u32 = #version;
     };
 
+    let mem = str::from_utf8(include_bytes!("mem.rs")).unwrap();
+    let mem: File = parse_str(&mem).unwrap();
+    tokens.extend(quote! {
+        #mem
+    });
+
     tokens.extend(quote! {
         #[panic_handler]
         #[no_mangle]
@@ -111,6 +118,7 @@ pub fn program(input: TokenStream) -> TokenStream {
             loop {}
         }
     });
+
     tokens.into()
 }
 

--- a/redbpf-macros/src/mem.rs
+++ b/redbpf-macros/src/mem.rs
@@ -1,0 +1,65 @@
+#[allow(warnings)]
+#[cfg(target_pointer_width = "16")]
+type c_int = i16;
+#[allow(warnings)]
+#[cfg(not(target_pointer_width = "16"))]
+type c_int = i32;
+
+#[no_mangle]
+pub unsafe extern "C" fn memcpy(dest: *mut u8, src: *const u8, n: usize) -> *mut u8 {
+    let mut i = 0;
+    while i < n {
+        *dest.offset(i as isize) = *src.offset(i as isize);
+        i += 1;
+    }
+    dest
+}
+
+#[no_mangle]
+pub unsafe extern "C" fn memmove(dest: *mut u8, src: *const u8, n: usize) -> *mut u8 {
+    if src < dest as *const u8 {
+        // copy from end
+        let mut i = n;
+        while i != 0 {
+            i -= 1;
+            *dest.offset(i as isize) = *src.offset(i as isize);
+        }
+    } else {
+        // copy from beginning
+        let mut i = 0;
+        while i < n {
+            *dest.offset(i as isize) = *src.offset(i as isize);
+            i += 1;
+        }
+    }
+    dest
+}
+
+#[no_mangle]
+pub unsafe extern "C" fn memset(s: *mut u8, c: c_int, n: usize) -> *mut u8 {
+    let mut i = 0;
+    while i < n {
+        *s.offset(i as isize) = c as u8;
+        i += 1;
+    }
+    s
+}
+
+#[no_mangle]
+pub unsafe extern "C" fn memcmp(s1: *const u8, s2: *const u8, n: usize) -> i32 {
+    let mut i = 0;
+    while i < n {
+        let a = *s1.offset(i as isize);
+        let b = *s2.offset(i as isize);
+        if a != b {
+            return a as i32 - b as i32;
+        }
+        i += 1;
+    }
+    0
+}
+
+#[no_mangle]
+pub unsafe extern "C" fn bcmp(s1: *const u8, s2: *const u8, n: usize) -> i32 {
+    memcmp(s1, s2, n)
+}


### PR DESCRIPTION
Make probe!() generate memory builtins including: memcpy, memmove,
memset, memcmp and bcmp.

This makes it possible to compare byte slices like `if &buffer == b"HTTP/1.1" { ...`