### PR TITLE
redefine asm_inline as it is not supported by clang

### DIFF
--- a/include/redbpf_helpers.h
+++ b/include/redbpf_helpers.h
@@ -4,6 +4,10 @@
 #undef asm_volatile_goto
 #define asm_volatile_goto(x...) asm volatile("invalid use of asm_volatile_goto")
 #endif
+#ifdef asm_inline
+#undef asm_inline
+#define asm_inline asm
+#endif
 #include <linux/version.h>
 #include <uapi/linux/ptrace.h>
 #include <uapi/linux/bpf.h>


### PR DESCRIPTION
hello,

when building with Linux headers 5.4.7 from archlinux, I got this error in bindgen:

```
   Compiling redbpf v0.9.7
   Compiling redbpf-probes v0.9.7
error: failed to run custom build command for `redbpf-probes v0.9.7`

Caused by:
  process didn't exit successfully: `/home/geal/dev/rust/projects/bpftest/bpf_examples/target/release/build/redbpf-probes-13194bc89ee16ca3/build-script-build` (exit code: 101)
--- stderr
/lib/modules/5.4.7-arch1-1/build/arch/x86/include/asm/segment.h:266:2: error: expected '(' after 'asm'
/lib/modules/5.4.7-arch1-1/build/arch/x86/include/asm/page_64.h:49:2: error: expected '(' after 'asm'
/lib/modules/5.4.7-arch1-1/build/arch/x86/include/asm/special_insns.h:205:2: error: expected '(' after 'asm'
/lib/modules/5.4.7-arch1-1/build/arch/x86/include/asm/processor.h:795:2: error: expected '(' after 'asm'
/lib/modules/5.4.7-arch1-1/build/arch/x86/include/asm/processor.h:807:2: error: expected '(' after 'asm'
/lib/modules/5.4.7-arch1-1/build/include/linux/thread_info.h:134:2: error: expected '(' after 'asm'
/lib/modules/5.4.7-arch1-1/build/include/linux/rcupdate.h:893:2: error: expected '(' after 'asm'
/lib/modules/5.4.7-arch1-1/build/include/linux/ktime.h:171:2: error: expected '(' after 'asm'
/lib/modules/5.4.7-arch1-1/build/include/linux/srcu.h:179:2: error: expected '(' after 'asm'
/lib/modules/5.4.7-arch1-1/build/include/asm-generic/fixmap.h:38:2: error: expected '(' after 'asm'
/lib/modules/5.4.7-arch1-1/build/arch/x86/include/asm/apic.h:107:2: error: expected '(' after 'asm'
/lib/modules/5.4.7-arch1-1/build/include/linux/dynamic_queue_limits.h:75:2: error: expected '(' after 'asm'
/lib/modules/5.4.7-arch1-1/build/include/linux/page-flags.h:565:2: error: expected '(' after 'asm'
/lib/modules/5.4.7-arch1-1/build/include/linux/slab.h:386:2: error: expected '(' after 'asm'
/lib/modules/5.4.7-arch1-1/build/arch/x86/include/asm/smap.h:47:2: error: expected '(' after 'asm'
/lib/modules/5.4.7-arch1-1/build/arch/x86/include/asm/smap.h:53:2: error: expected '(' after 'asm'
/lib/modules/5.4.7-arch1-1/build/arch/x86/include/asm/uaccess_64.h:37:2: error: expected '(' after 'asm'
/lib/modules/5.4.7-arch1-1/build/arch/x86/include/asm/uaccess_64.h:74:3: error: expected '(' after 'asm'
/lib/modules/5.4.7-arch1-1/build/arch/x86/include/asm/uaccess_64.h:80:3: error: expected '(' after 'asm'
fatal error: too many errors emitted, stopping now [-ferror-limit=]
/lib/modules/5.4.7-arch1-1/build/arch/x86/include/asm/segment.h:266:2: error: expected '(' after 'asm', err: true
/lib/modules/5.4.7-arch1-1/build/arch/x86/include/asm/page_64.h:49:2: error: expected '(' after 'asm', err: true
/lib/modules/5.4.7-arch1-1/build/arch/x86/include/asm/special_insns.h:205:2: error: expected '(' after 'asm', err: true
/lib/modules/5.4.7-arch1-1/build/arch/x86/include/asm/processor.h:795:2: error: expected '(' after 'asm', err: true
/lib/modules/5.4.7-arch1-1/build/arch/x86/include/asm/processor.h:807:2: error: expected '(' after 'asm', err: true
/lib/modules/5.4.7-arch1-1/build/include/linux/thread_info.h:134:2: error: expected '(' after 'asm', err: true
/lib/modules/5.4.7-arch1-1/build/include/linux/rcupdate.h:893:2: error: expected '(' after 'asm', err: true
/lib/modules/5.4.7-arch1-1/build/include/linux/ktime.h:171:2: error: expected '(' after 'asm', err: true
/lib/modules/5.4.7-arch1-1/build/include/linux/srcu.h:179:2: error: expected '(' after 'asm', err: true
/lib/modules/5.4.7-arch1-1/build/include/asm-generic/fixmap.h:38:2: error: expected '(' after 'asm', err: true
/lib/modules/5.4.7-arch1-1/build/arch/x86/include/asm/apic.h:107:2: error: expected '(' after 'asm', err: true
/lib/modules/5.4.7-arch1-1/build/include/linux/dynamic_queue_limits.h:75:2: error: expected '(' after 'asm', err: true
/lib/modules/5.4.7-arch1-1/build/include/linux/page-flags.h:565:2: error: expected '(' after 'asm', err: true
/lib/modules/5.4.7-arch1-1/build/include/linux/slab.h:386:2: error: expected '(' after 'asm', err: true
/lib/modules/5.4.7-arch1-1/build/arch/x86/include/asm/smap.h:47:2: error: expected '(' after 'asm', err: true
/lib/modules/5.4.7-arch1-1/build/arch/x86/include/asm/smap.h:53:2: error: expected '(' after 'asm', err: true
/lib/modules/5.4.7-arch1-1/build/arch/x86/include/asm/uaccess_64.h:37:2: error: expected '(' after 'asm', err: true
/lib/modules/5.4.7-arch1-1/build/arch/x86/include/asm/uaccess_64.h:74:3: error: expected '(' after 'asm', err: true
/lib/modules/5.4.7-arch1-1/build/arch/x86/include/asm/uaccess_64.h:80:3: error: expected '(' after 'asm', err: true
fatal error: too many errors emitted, stopping now [-ferror-limit=], err: true
thread 'main' panicked at 'Unable to generate bindings!: ()', src/libcore/result.rs:1165:5
note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace.
```

This is caused by some kernel macros generating `asm __inline`. This patch should fix it