### PR TITLE
Hide the unsafe to_str function

### DIFF
--- a/bpf-sys/src/uname.rs
+++ b/bpf-sys/src/uname.rs
@@ -49,7 +49,9 @@ pub fn get_fqdn() -> Result<String, ()> {
 }
 
 #[inline]
-pub fn to_str(bytes: &[c_char]) -> &str {
+fn to_str(bytes: &[c_char]) -> &str {
+    // SAFETY: only called on `uname` structs filled by the OS, which we trust.
+    // FIXME: Do not trust it to be valid UTF-8.
     unsafe { from_utf8_unchecked(CStr::from_ptr(bytes.as_ptr()).to_bytes()) }
 }
 

--- a/bpf-sys/src/uname.rs
+++ b/bpf-sys/src/uname.rs
@@ -51,7 +51,6 @@ pub fn get_fqdn() -> Result<String, ()> {
 #[inline]
 fn to_str(bytes: &[c_char]) -> &str {
     // SAFETY: only called on `uname` structs filled by the OS, which we trust.
-    // FIXME: Do not trust it to be valid UTF-8.
     unsafe { from_utf8_unchecked(CStr::from_ptr(bytes.as_ptr()).to_bytes()) }
 }
 


### PR DESCRIPTION
The implementation makes the assumption that the bytes making up the
C-string are both terminated and valid. This is wrong in general but
the zero-termination seems permissible as it only trusts the kernel's
correct implementation of POSIX.

The correct encoding trust is a different beast, there might be an
unterminated multi-byte character within the string. Also, the implicit trust 
on correct encoding of kernel files is present in a few other places as well
and might warrant a separate tracking issue if it should be addressed.