### PR TITLE
 redbpf, redbpf-probes: split user/kernel space MapData

### DIFF
--- a/cargo-bpf/src/load.rs
+++ b/cargo-bpf/src/load.rs
@@ -9,7 +9,7 @@ use crate::CommandError;
 
 use hexdump::hexdump;
 use redbpf::load::Loader;
-use redbpf::XdpFlags;
+use redbpf::xdp;
 use std::path::PathBuf;
 use futures::stream::StreamExt;
 use tokio;
@@ -20,7 +20,7 @@ pub fn load(program: &PathBuf, interface: Option<&str>) -> Result<(), CommandErr
     let mut runtime = Runtime::new().unwrap();
     let _ = runtime.block_on(async {
         let mut loader = Loader::new()
-            .xdp(interface.map(String::from), XdpFlags::default())
+            .xdp(interface.map(String::from), xdp::Flags::default())
             .load_file(&program)
             .await
             .expect("error loading file");

--- a/redbpf-probes/src/xdp.rs
+++ b/redbpf-probes/src/xdp.rs
@@ -243,12 +243,11 @@ impl Data {
         }
     }
 }
-
+/* NB: this needs to be kept in sync with redbpf::xdp::MapData */
 /// Convenience data type to exchange payload data.
 #[repr(C)]
 pub struct MapData<T> {
-    /// The custom data type to be exchanged with user space.
-    pub data: T,
+    data: T,
     offset: u32,
     size: u32,
     payload: [u8; 0],
@@ -271,14 +270,6 @@ impl<T> MapData<T> {
             payload: [],
             offset,
             size
-        }
-    }
-
-    /// Return the payload if any, skipping the initial `offset` bytes.
-    pub fn payload(&self) -> &[u8] {
-        unsafe {
-            let base = self.payload.as_ptr().add(self.offset as usize);
-            slice::from_raw_parts(base, (self.size - self.offset) as usize)
         }
     }
 }

--- a/redbpf-probes/src/xdp.rs
+++ b/redbpf-probes/src/xdp.rs
@@ -264,7 +264,10 @@ impl<T> MapData<T> {
     /// bytes, where the interesting part of the payload starts at `offset`.
     ///
     /// The payload can then be retrieved calling `MapData::payload()`.
+    ///
+    /// The function will panic if `offset > size`.
     pub fn with_payload(data: T, offset: u32, size: u32) -> Self {
+        assert!(offset <= size);
         Self {
             data,
             payload: [],

--- a/redbpf/src/load/loader.rs
+++ b/redbpf/src/load/loader.rs
@@ -15,7 +15,7 @@ use std::path::PathBuf;
 
 use crate::cpus;
 use crate::ProgramKind::*;
-use crate::{LoadError, Module, PerfMap, XdpFlags};
+use crate::{LoadError, Module, PerfMap, xdp};
 use crate::load::map_io::PerfMessageStream;
 
 #[derive(Debug)]
@@ -41,7 +41,7 @@ impl Loader {
     }
 
     /// Sets the network interface and flags for XDP programs.
-    pub fn xdp(&mut self, interface: Option<String>, flags: XdpFlags) -> &mut Self {
+    pub fn xdp(&mut self, interface: Option<String>, flags: xdp::Flags) -> &mut Self {
         self.xdp = XdpConfig {
             interface,
             flags
@@ -139,14 +139,14 @@ impl Drop for Loaded {
 #[derive(Debug, Clone)]
 pub struct XdpConfig {
     interface: Option<String>,
-    flags: XdpFlags
+    flags: xdp::Flags
 }
 
 impl Default for XdpConfig {
     fn default() -> XdpConfig {
         XdpConfig {
             interface: None,
-            flags: XdpFlags::default()
+            flags: xdp::Flags::default()
         }
     }
 }

--- a/redbpf/src/xdp.rs
+++ b/redbpf/src/xdp.rs
@@ -21,3 +21,30 @@ impl Default for Flags {
         Flags::Unset
     }
 }
+
+/* NB: this needs to be kept in sync with redbpf_probes::xdp::MapData */
+#[repr(C)]
+pub struct MapData<T> {
+    /// The custom data type to be exchanged with user space.
+    data: T,
+    offset: u32,
+    size: u32,
+    payload: [u8; 0],
+}
+
+impl<T> MapData<T> {
+    /// Return the data shared by the kernel space program.
+    pub fn data(&self) -> &T {
+        &self.data
+    }
+
+    /// Return the XDP payload shared by the kernel space program.
+    ///
+    /// Returns an empty slice if the kernel space program didn't share any XDP payload.
+    pub fn payload(&self) -> &[u8] {
+        unsafe {
+            let base = self.payload.as_ptr().add(self.offset as usize);
+            slice::from_raw_parts(base, (self.size - self.offset) as usize)
+        }
+    }
+}

--- a/redbpf/src/xdp.rs
+++ b/redbpf/src/xdp.rs
@@ -1,0 +1,23 @@
+use std::slice;
+use std::default::Default;
+
+use bpf_sys::{XDP_FLAGS_UPDATE_IF_NOEXIST, XDP_FLAGS_SKB_MODE,
+              XDP_FLAGS_DRV_MODE, XDP_FLAGS_HW_MODE, XDP_FLAGS_MODES, XDP_FLAGS_MASK};
+
+#[derive(Debug, Clone, Copy)]
+#[repr(u32)]
+pub enum Flags {
+    Unset = 0,
+    UpdateIfNoExist = XDP_FLAGS_UPDATE_IF_NOEXIST,
+    SkbMode = XDP_FLAGS_SKB_MODE,
+    DrvMode = XDP_FLAGS_DRV_MODE,
+    HwMode = XDP_FLAGS_HW_MODE,
+    Modes = XDP_FLAGS_MODES,
+    Mask = XDP_FLAGS_MASK
+}
+
+impl Default for Flags {
+    fn default() -> Self {
+        Flags::Unset
+    }
+}

--- a/redbpf/src/xdp.rs
+++ b/redbpf/src/xdp.rs
@@ -3,6 +3,7 @@ use std::default::Default;
 
 use bpf_sys::{XDP_FLAGS_UPDATE_IF_NOEXIST, XDP_FLAGS_SKB_MODE,
               XDP_FLAGS_DRV_MODE, XDP_FLAGS_HW_MODE, XDP_FLAGS_MODES, XDP_FLAGS_MASK};
+use crate::Sample;
 
 #[derive(Debug, Clone, Copy)]
 #[repr(u32)]
@@ -33,6 +34,10 @@ pub struct MapData<T> {
 }
 
 impl<T> MapData<T> {
+    pub unsafe fn from_sample<U>(sample: &Sample) -> &MapData<U> {
+        &*(sample.data.as_ptr() as *const MapData<U>)
+    }
+
     /// Return the data shared by the kernel space program.
     pub fn data(&self) -> &T {
         &self.data


### PR DESCRIPTION
With this change redbpf_probes::xdp::MapData only includes the kernel space API. The user space API is now in redbpf::xdp::MapData.

This closes https://github.com/redsift/redbpf/issues/23.
