### PR TITLE
Add support for panic!()

### DIFF
--- a/cargo-bpf/Cargo.toml
+++ b/cargo-bpf/Cargo.toml
@@ -21,3 +21,5 @@ redbpf = { version = "^0.9.9", features = ["build", "load"], path = "../redbpf" 
 futures = "0.3"
 tokio = { version = "0.2.4", features = ["rt-core", "io-driver", "macros", "signal"] }
 hexdump = "0.1"
+libc = "0.2.66"
+llvm-sys = "90"

--- a/cargo-bpf/src/build.rs
+++ b/cargo-bpf/src/build.rs
@@ -5,6 +5,7 @@
 // http://opensource.org/licenses/MIT>, at your option. This file may not be
 // copied, modified, or distributed except according to those terms.
 
+use libc;
 use std::convert::From;
 use std::env;
 use std::fmt::{self, Display};
@@ -12,8 +13,11 @@ use std::fs;
 use std::io;
 use std::path::{Path, PathBuf};
 use std::process::Command;
+use std::slice;
+use std::str;
 use toml_edit;
 
+use crate::llvm::process_ir;
 use crate::CommandError;
 
 #[derive(Debug)]
@@ -21,7 +25,8 @@ pub enum Error {
     MissingManifest(PathBuf),
     NoPrograms,
     NoLLC,
-    Compile(String),
+    NoOPT,
+    Compile(String, Option<String>),
     MissingBitcode(String),
     Link(String),
     IOError(io::Error),
@@ -48,9 +53,11 @@ impl Display for Error {
         match self {
             MissingManifest(p) => write!(f, "Could not find `Cargo.toml' in {:?}", p),
             NoPrograms => write!(f, "the package doesn't contain any eBPF programs"),
-            Compile(p) => write!(f, "failed to compile the `{}' program", p),
+            Compile(p, Some(msg)) => write!(f, "failed to compile the `{}' program: {}", p, msg),
+            Compile(p, None) => write!(f, "failed to compile the `{}' program", p),
             MissingBitcode(p) => write!(f, "failed to generate bitcode for the `{}' program", p),
             Link(p) => write!(f, "failed to generate bitcode for the `{}' program", p),
+            NoOPT => write!(f, "no usable opt executable found, expecting version 9"),
             NoLLC => write!(f, "no usable llc executable found, expecting version 9"),
             IOError(e) => write!(f, "{}", e),
         }
@@ -83,15 +90,18 @@ pub fn build_program(
         .arg("--bin")
         .arg(program)
         .arg("--")
-        .args("--emit=llvm-bc -C panic=abort -C link-arg=-nostartfiles -C opt-level=3".split(" "))
+        .args(
+            "--emit=llvm-bc -C panic=abort -C lto -C link-arg=-nostartfiles -C opt-level=3"
+                .split(" "),
+        )
         .args(format!("-o {}/{}", out_dir.to_str().unwrap(), program).split(" "))
         .status()?
         .success()
     {
-        return Err(Error::Compile(program.to_string()));
+        return Err(Error::Compile(program.to_string(), None));
     }
 
-    let bc_files: Vec<PathBuf> = fs::read_dir(out_dir)?
+    let mut bc_files: Vec<PathBuf> = fs::read_dir(out_dir)?
         .filter(|e| {
             e.as_ref()
                 .unwrap()
@@ -106,12 +116,31 @@ pub fn build_program(
         return Err(Error::MissingBitcode(program.to_string()));
     }
 
-    let bc_file = &bc_files[0];
+    let bc_file = bc_files.drain(..).next().unwrap();
+    let processed_bc_file = bc_file.with_extension("bc.proc");
+    let opt_bc_file = bc_file.with_extension("bc.opt");
+
+    process_ir(&bc_file, &processed_bc_file).map_err(|msg| {
+        Error::Compile(program.into(), Some(format!("couldn't process IR file: {}", msg)))
+    })?;
+    println!("IR processed before: {:?}, after: {:?}", bc_file, processed_bc_file);
+
+    let opt = get_opt_executable()?;
+    if !Command::new(opt)
+        .args(&["-march=bpf", "-O3", "-o", opt_bc_file.to_str().unwrap()])
+        .arg(processed_bc_file.to_str().unwrap())
+        .status()?
+        .success()
+    {
+        return Err(Error::Link(program.to_string()));
+    }
+    println!("IR optimised: {:?}", opt_bc_file);
+
     let llc = get_llc_executable()?;
     if !Command::new(llc)
         .args(&llc_args)
         .arg(&elf_target)
-        .arg(bc_file.to_str().unwrap())
+        .arg(opt_bc_file.to_str().unwrap())
         .status()?
         .success()
     {
@@ -119,6 +148,23 @@ pub fn build_program(
     }
 
     Ok(())
+}
+
+fn get_opt_executable() -> Result<String, Error> {
+    for llc in vec!["opt".into(), env::var("OPT").unwrap_or("opt-9".into())].drain(..) {
+        if let Ok(out) = Command::new(&llc).arg("--version").output() {
+            match String::from_utf8(out.stdout) {
+                Ok(out) => {
+                    if out.contains("LLVM version 9.") {
+                        return Ok(llc);
+                    }
+                }
+                Err(_) => continue,
+            }
+        }
+    }
+
+    return Err(Error::NoOPT);
 }
 
 fn get_llc_executable() -> Result<String, Error> {

--- a/cargo-bpf/src/lib.rs
+++ b/cargo-bpf/src/lib.rs
@@ -7,6 +7,7 @@
 
 mod bindgen;
 mod build;
+mod llvm;
 mod load;
 mod new;
 mod new_program;

--- a/cargo-bpf/src/llvm.rs
+++ b/cargo-bpf/src/llvm.rs
@@ -1,0 +1,148 @@
+use llvm_sys::analysis::{LLVMVerifierFailureAction::*, LLVMVerifyModule};
+use llvm_sys::core::*;
+use llvm_sys::debuginfo::LLVMStripModuleDebugInfo;
+use llvm_sys::initialization::*;
+use llvm_sys::ir_reader::LLVMParseIRInContext;
+use llvm_sys::prelude::*;
+use llvm_sys::target::*;
+use llvm_sys::{LLVMAttributeFunctionIndex, LLVMInlineAsmDialect::*};
+use std::ffi::{CStr, CString};
+use std::os::raw::c_char;
+use std::path::Path;
+use std::ptr;
+
+unsafe fn init_context() -> LLVMContextRef {
+    let context = LLVMGetGlobalContext();
+
+    LLVM_InitializeAllTargets();
+    LLVM_InitializeAllTargetMCs();
+    LLVM_InitializeAllAsmPrinters();
+    LLVM_InitializeAllAsmParsers();
+
+    let registry = LLVMGetGlobalPassRegistry();
+    LLVMInitializeCore(registry);
+    LLVMInitializeCodeGen(registry);
+    LLVMInitializeScalarOpts(registry);
+    LLVMInitializeVectorization(registry);
+
+    context
+}
+
+unsafe fn load_module(context: LLVMContextRef, input: &Path) -> Result<LLVMModuleRef, String> {
+    let mut message: *mut c_char = ptr::null_mut();
+    let filename = CString::new(input.to_str().unwrap()).unwrap();
+    let mut buf: LLVMMemoryBufferRef = ptr::null_mut();
+    LLVMCreateMemoryBufferWithContentsOfFile(
+        filename.as_ptr(),
+        &mut buf as *mut _,
+        &mut message as *mut *mut c_char,
+    );
+    if !message.is_null() {
+        let message = CStr::from_ptr(message);
+        return Err(message.to_string_lossy().into_owned());
+    }
+
+    let mut module: LLVMModuleRef = ptr::null_mut();
+    let mut message: *mut c_char = ptr::null_mut();
+    LLVMParseIRInContext(
+        context,
+        buf,
+        &mut module as *mut _,
+        &mut message as *mut *mut c_char,
+    );
+    if !message.is_null() {
+        let message = CStr::from_ptr(message);
+        return Err(message.to_string_lossy().into_owned());
+    }
+
+    Ok(module)
+}
+
+unsafe fn write_module(module: LLVMModuleRef, path: &Path) -> Result<(), String> {
+    let mut message: *mut c_char = ptr::null_mut();
+    let ret = LLVMVerifyModule(module, LLVMPrintMessageAction, &mut message as *mut *mut _);
+    if ret == 1 && !message.is_null() {
+        let message = CStr::from_ptr(message);
+        return Err(format!(
+            "verification failed: {}",
+            message.to_string_lossy().into_owned()
+        ));
+    }
+
+    let mut message: *mut c_char = ptr::null_mut();
+    let out = CString::new(path.to_str().unwrap()).unwrap();
+    LLVMPrintModuleToFile(module, out.as_ptr(), &mut message as *mut *mut _);
+    if !message.is_null() {
+        let message = CStr::from_ptr(message);
+        return Err(message.to_string_lossy().into_owned());
+    }
+
+    Ok(())
+}
+
+unsafe fn inject_exit_call(context: LLVMContextRef, func: LLVMValueRef, builder: LLVMBuilderRef) {
+    let exit_str = CString::new("exit").unwrap();
+    let exit_sig = LLVMFunctionType(LLVMVoidTypeInContext(context), ptr::null_mut(), 0, 0);
+    let exit = LLVMGetInlineAsm(
+        exit_sig,
+        exit_str.as_ptr() as *mut _,
+        "exit".len(),
+        ptr::null_mut(),
+        0,
+        0,
+        0,
+        LLVMInlineAsmDialectATT,
+    );
+
+    let block = LLVMGetLastBasicBlock(func);
+    let last = LLVMGetLastInstruction(block);
+    LLVMPositionBuilderBefore(builder, last);
+    LLVMBuildCall(
+        builder,
+        exit,
+        ptr::null_mut(),
+        0,
+        CString::new("").unwrap().as_ptr(),
+    );
+}
+
+pub fn process_ir(input: &Path, output: &Path) -> Result<(), String> {
+    unsafe {
+        let context = init_context();
+        let module = load_module(context, input)?;
+        let builder = LLVMCreateBuilderInContext(context);
+
+        let no_inline = CString::new("noinline").unwrap();
+        let no_inline_kind = LLVMGetEnumAttributeKindForName(no_inline.as_ptr(), "noinline".len());
+        let always_inline = CString::new("alwaysinline").unwrap();
+        let always_inline_kind =
+            LLVMGetEnumAttributeKindForName(always_inline.as_ptr(), "alwaysinline".len());
+        let always_inline_attr = LLVMCreateEnumAttribute(context, always_inline_kind, 0);
+
+        let mut func = LLVMGetFirstFunction(module);
+        while func != ptr::null_mut() {
+            let mut size: libc::size_t = 0;
+            let name = CStr::from_ptr(LLVMGetValueName2(func, &mut size as *mut _))
+                .to_str()
+                .unwrap();
+            if !name.starts_with("llvm.") {
+                // make sure everything gets inlined as BPF can't do calls to
+                // things other than helpers
+                LLVMRemoveEnumAttributeAtIndex(func, LLVMAttributeFunctionIndex, no_inline_kind);
+                LLVMAddAttributeAtIndex(func, LLVMAttributeFunctionIndex, always_inline_attr);
+
+                if name == "rust_begin_unwind" {
+                    // inject a BPF exit call in the panic handler to make the program terminate
+                    inject_exit_call(context, func, builder);
+                }
+            }
+            func = LLVMGetNextFunction(func);
+        }
+
+        // the debug info generated by rustc seems to trigger a segfault in the
+        // BTF code in llvm, so strip it until that is fixed
+        LLVMStripModuleDebugInfo(module);
+
+        write_module(module, output)
+    }
+}

--- a/redbpf-probes/Cargo.toml
+++ b/redbpf-probes/Cargo.toml
@@ -12,6 +12,7 @@ license = "MIT OR Apache-2.0"
 [dependencies]
 cty = "0.2"
 redbpf-macros = { version = "^0.9.9", path = "../redbpf-macros" }
+ufmt = { version = "0.1.0", default-features = false }
 
 [build-dependencies]
 bindgen = "0.51"

--- a/redbpf-probes/src/helpers.rs
+++ b/redbpf-probes/src/helpers.rs
@@ -1,11 +1,51 @@
 use core::mem::{size_of, MaybeUninit};
 
-use cty::*;
 use crate::bindings::*;
-
+use cty::*;
+pub use ufmt;
+use ufmt::uWrite;
 mod gen {
     include!(concat!(env!("OUT_DIR"), "/gen_helpers.rs"));
 }
+
+pub struct TraceMessage {
+    msg: [u8; 50],
+    write_i: usize
+}
+
+impl TraceMessage {
+    #[inline]
+    pub fn new() -> Self {
+        TraceMessage {
+            msg: unsafe { core::mem::MaybeUninit::uninit().assume_init() },
+            write_i: 0
+        }
+    }
+
+    #[inline]
+    pub fn printk(&self) {
+        bpf_trace_printk(&self.msg[..self.write_i]);
+    }
+}
+
+impl uWrite for TraceMessage {
+    type Error = ();
+
+    #[inline]
+    fn write_str(&mut self, s: &str) -> Result<(), Self::Error> {
+        let bytes = s.as_bytes();
+        let len = bytes.len();
+        let available = self.msg.len() - self.write_i;
+        if available < len {
+            return Err(());
+        }
+
+        self.msg[self.write_i..self.write_i + len].copy_from_slice(bytes);
+        self.write_i += len;
+        Ok(())
+    }
+}
+
 
 pub use gen::*;
 
@@ -42,6 +82,18 @@ pub fn bpf_probe_read<T>(src: *const T) -> T {
         );
 
         v.assume_init()
+    }
+}
+
+#[inline]
+pub fn bpf_trace_printk(message: &[u8]) -> ::cty::c_int {
+    unsafe {
+        let f: unsafe extern "C" fn(fmt: *const ::cty::c_char, fmt_size: __u32) -> ::cty::c_int =
+            ::core::mem::transmute(6usize);
+        f(
+            message.as_ptr() as *const ::cty::c_char,
+            message.len() as u32,
+        )
     }
 }
 


### PR DESCRIPTION
Before this change, code that *potentially* called panic!() would fail to link, as core::panicking::{panic,panic_bound_check,panic_fmt} were not being inlined. That meant that even indexing arrays, unless bounds checks were somehow being elided, could result in compilation failures.

This change introduces a LLVM IR transform pass which among other things forces core::panicking::* to be inlined, and patches the panic handler to use the BPF exit opcode to terminate execution.

If nothing calls panic!(), no extra code gets emitted. If something does panic, you now get a log line in /sys/kernel/debug/tracing/trace_pipe saying "panic in [filename of the BPF program that panicked].rs".