### PR TITLE
redbpf-probes: make XdpContext::read work for arrays up to 512 bytes

### DIFF
--- a/redbpf-macros/src/lib.rs
+++ b/redbpf-macros/src/lib.rs
@@ -129,6 +129,18 @@ pub fn program(input: TokenStream) -> TokenStream {
     tokens.into()
 }
 
+#[proc_macro]
+pub fn impl_xdp_array(_: TokenStream) -> TokenStream {
+    let mut tokens = TokenStream2::new();
+    for i in 1..=512usize {
+        tokens.extend(quote! {
+            impl XdpArray for [u8; #i] {}
+        });
+    }
+
+    tokens.into()
+}
+
 /// Attribute macro that must be used when creating [eBPF
 /// maps](https://redsift.github.io/rust/redbpf/doc/redbpf_probes/maps/index.html).
 ///

--- a/redbpf-probes/src/xdp.rs
+++ b/redbpf-probes/src/xdp.rs
@@ -44,7 +44,12 @@ use cty::*;
 use crate::bindings::*;
 use crate::maps::{PerfMap as PerfMapBase, PerfMapFlags};
 
-/// The return type of XDP probes.
+use redbpf_macros::impl_xdp_array;
+
+pub trait XdpArray {}
+impl_xdp_array!();
+
+/// The return type of XDP probes}
 #[repr(u32)]
 pub enum XdpAction {
     /// Signals that the program had an unexpected anomaly. Should only be used
@@ -233,7 +238,7 @@ impl Data {
     }
 
     #[inline]
-    pub fn read<T>(&self) -> Option<T> {
+    pub fn read<T: XdpArray>(&self) -> Option<T> {
         unsafe {
             let len = mem::size_of::<T>();
             if self.base.add(len) as *const u8 > (*self.ctx).data_end as *const u8 {


### PR DESCRIPTION
This fixes the soundness issue described in https://github.com/redsift/redbpf/issues/20#issuecomment-568390531