### PR TITLE
Consolidate bindgen code and improve bindings

### DIFF
--- a/cargo-bpf/Cargo.toml
+++ b/cargo-bpf/Cargo.toml
@@ -23,3 +23,6 @@ tokio = { version = "0.2.4", features = ["rt-core", "io-driver", "macros", "sign
 hexdump = "0.1"
 libc = "0.2.66"
 llvm-sys = "90"
+syn = {version = "1.0", features = ["full", "visit", "extra-traits"] }
+quote = "1.0"
+proc-macro2 = "1.0"

--- a/cargo-bpf/Cargo.toml
+++ b/cargo-bpf/Cargo.toml
@@ -26,3 +26,4 @@ llvm-sys = "90"
 syn = {version = "1.0", features = ["full", "visit", "extra-traits"] }
 quote = "1.0"
 proc-macro2 = "1.0"
+tempfile = "3.1"

--- a/cargo-bpf/src/accessors.rs
+++ b/cargo-bpf/src/accessors.rs
@@ -1,0 +1,186 @@
+use proc_macro2::{Ident, Span};
+use quote::quote;
+use std::collections::{HashMap, HashSet};
+use std::fs;
+use syn::visit::{visit_item_struct, Visit};
+use syn::{self, parse_str, Field, File, Item, ItemStruct, ItemUnion, Path, Type, TypePath};
+
+// toplevel syn items
+type Items = HashMap<Ident, Item>;
+
+struct CollectItems {
+    items: Items,
+}
+
+impl CollectItems {
+    fn new() -> Self {
+        CollectItems {
+            items: Items::new(),
+        }
+    }
+}
+
+impl<'ast> Visit<'ast> for CollectItems {
+    fn visit_item_struct(&mut self, node: &ItemStruct) {
+        self.items
+            .insert(node.ident.clone(), Item::Struct(node.clone()));
+    }
+
+    fn visit_item_union(&mut self, node: &ItemUnion) {
+        self.items
+            .insert(node.ident.clone(), Item::Union(node.clone()));
+    }
+}
+#[derive(Debug)]
+struct Accessor {
+    prefix: Vec<String>,
+    field: Field,
+}
+
+struct GenerateAccessors {
+    items: Items,
+    whitelist: HashSet<String>,
+    prefix: Vec<String>,
+    accessors: Vec<Accessor>,
+    type_accessors: HashMap<String, Vec<Accessor>>,
+}
+
+impl GenerateAccessors {
+    fn new(items: Items, whitelist: HashSet<String>) -> Self {
+        GenerateAccessors {
+            items,
+            whitelist,
+            accessors: Vec::new(),
+            type_accessors: HashMap::new(),
+            prefix: Vec::new(),
+        }
+    }
+
+    fn type_item(&self, ty: &Type) -> &Item {
+        let ident = match ty {
+            Type::Path(TypePath {
+                path: Path { ref segments, .. },
+                ..
+            }) => segments.first().unwrap().ident.clone(),
+            _ => panic!(),
+        };
+
+        self.items.get(&ident).unwrap()
+    }
+
+    fn enter_field(&self, id_s: &str) -> bool {
+        id_s.starts_with("__bindgen_anon") || id_s.starts_with("__sk_common")
+    }
+
+    fn toplevel_visit(&self) -> bool {
+        self.prefix.is_empty()
+    }
+
+    fn is_whitelisted(&self, ident: &Ident) -> bool {
+        self.whitelist.contains(&ident.to_string())
+    }
+
+    fn blacklisted_field(&self, id_s: &str) -> bool {
+        if id_s.starts_with("_bindgen") || id_s.starts_with("_bitfield") {
+            return true;
+        }
+
+        false
+    }
+}
+
+impl<'ast> Visit<'ast> for GenerateAccessors {
+    fn visit_item_struct(&mut self, node: &ItemStruct) {
+        let toplevel = self.toplevel_visit();
+        if toplevel {
+            if !self.is_whitelisted(&node.ident) {
+                return;
+            }
+            self.prefix.push("self".to_string());
+        }
+
+        visit_item_struct(self, node);
+        // this function is called recursively as types are parsed. We want to
+        // generate accessors only when parsing toplevel items.
+        if toplevel {
+            if !self.accessors.is_empty() {
+                self.type_accessors
+                    .insert(node.ident.to_string(), self.accessors.drain(..).collect());
+            }
+            self.prefix.pop();
+        }
+    }
+
+    fn visit_field(&mut self, node: &Field) {
+        if self.prefix.is_empty() {
+            // visiting a field for a type for which we're not generating
+            // accessors
+            return;
+        }
+
+        let id_s = match &node.ident {
+            Some(i) => i.to_string(),
+            None => return,
+        };
+
+        if self.enter_field(&id_s) {
+            self.prefix.push(id_s);
+            let item = self.type_item(&node.ty).clone();
+            self.visit_item(&item);
+            self.prefix.pop();
+        } else if !self.blacklisted_field(&id_s) {
+            self.accessors.push(Accessor {
+                prefix: self.prefix.clone(),
+                field: node.clone(),
+            });
+        }
+    }
+}
+
+fn parse_items(tree: &File) -> Items {
+    let mut ci = CollectItems::new();
+    ci.visit_file(tree);
+    ci.items
+}
+
+pub fn generate_read_accessors(bindings: &str, whitelist: &[&str]) -> String {
+    // parse the bindgen generated bindings
+    let tree: File = parse_str(&bindings).unwrap();
+
+    // discover the toplevel items, and generate accessors for the items
+    // included in the whitelist
+    let whitelist = whitelist.iter().map(|s| String::from(*s)).collect();
+    let mut accessors = GenerateAccessors::new(parse_items(&tree), whitelist);
+    accessors.visit_file(&tree);
+
+    // for each accessor, generate a getter that automatically reads the data
+    // via bpf_probe_read
+    let items = accessors
+        .type_accessors
+        .iter()
+        .map(|(item_id, item_accessors)| {
+            let accessors = item_accessors.iter().map(|acc| {
+                let ident = acc.field.ident.clone().unwrap();
+                let ty = &acc.field.ty;
+                let prefix = acc.prefix.iter().map(|p| Ident::new(p, Span::call_site()));
+                quote! {
+                    pub fn #ident(&self) -> #ty {
+                        bpf_probe_read(unsafe { &#(#prefix).*.#ident })
+                    }
+                }
+            });
+            let ident = Ident::new(item_id, Span::call_site());
+            let item = quote! {
+                impl #ident {
+                    #(#accessors)*
+                }
+            };
+            item.to_string()
+        });
+
+    let mut out = String::new();
+    for item in items {
+        out.push_str(&item);
+    }
+    out
+}

--- a/cargo-bpf/src/bindgen.rs
+++ b/cargo-bpf/src/bindgen.rs
@@ -13,6 +13,7 @@ use std::process::Command;
 use std::str;
 
 use crate::CommandError;
+pub use crate::accessors::generate_read_accessors;
 
 use redbpf::{self, build::headers::kernel_headers};
 

--- a/cargo-bpf/src/bindgen.rs
+++ b/cargo-bpf/src/bindgen.rs
@@ -6,6 +6,7 @@
 // copied, modified, or distributed except according to those terms.
 
 use bindgen;
+pub use bindgen::Builder;
 use std::io::{self, Write};
 use std::path::PathBuf;
 use std::process::Command;
@@ -15,7 +16,7 @@ use crate::CommandError;
 
 use redbpf::{self, build::headers::kernel_headers};
 
-pub fn cmd_bindgen(header: &PathBuf, extra_args: &[&str]) -> Result<(), CommandError> {
+pub fn builder() -> Builder {
     let kernel_headers = kernel_headers().expect("couldn't find kernel headers");
     let mut flags: Vec<String> = kernel_headers
         .iter()
@@ -27,12 +28,14 @@ pub fn cmd_bindgen(header: &PathBuf, extra_args: &[&str]) -> Result<(), CommandE
     flags.push("-Wno-address-of-packed-member".to_string());
     flags.push("-Wno-gnu-variable-sized-type-not-at-end".to_string());
 
-    let mut bindgen_flags = bindgen::builder()
+    bindgen::builder()
         .clang_args(&flags)
-        .header(header.to_str().unwrap())
         .use_core()
         .ctypes_prefix("::cty")
-        .command_line_flags();
+}
+
+pub fn generate(builder: &Builder, extra_args: &[&str]) -> String {
+    let mut bindgen_flags = builder.command_line_flags();
     let p = bindgen_flags
         .iter()
         .position(|arg| arg == "--")
@@ -40,10 +43,18 @@ pub fn cmd_bindgen(header: &PathBuf, extra_args: &[&str]) -> Result<(), CommandE
     for (i, flag) in extra_args.iter().enumerate() {
         bindgen_flags.insert(p + i, String::from(*flag));
     }
-    let output = Command::new("bindgen").args(bindgen_flags).output()?;
-    io::stderr().write_all(&output.stderr)?;
-    let bindings = output.stdout;
-    let bindings = str::from_utf8(&bindings).unwrap();
+    let output = Command::new("bindgen")
+        .args(bindgen_flags)
+        .output()
+        .expect("error running bindgen");
+    io::stderr().write_all(&output.stderr).unwrap();
+    let bindings = str::from_utf8(&output.stdout).unwrap();
+    bindings.to_string()
+}
+
+pub fn cmd_bindgen(header: &PathBuf, extra_args: &[&str]) -> Result<(), CommandError> {
+    let builder = builder().header(header.to_str().unwrap());
+    let bindings = generate(&builder, extra_args);
     let mut out = io::stdout();
     writeln!(
         &mut out,

--- a/cargo-bpf/src/lib.rs
+++ b/cargo-bpf/src/lib.rs
@@ -5,7 +5,7 @@
 // http://opensource.org/licenses/MIT>, at your option. This file may not be
 // copied, modified, or distributed except according to those terms.
 
-mod bindgen;
+pub mod bindgen;
 mod build;
 mod llvm;
 mod load;
@@ -20,7 +20,6 @@ impl std::convert::From<std::io::Error> for CommandError {
     }
 }
 
-pub use self::bindgen::cmd_bindgen as bindgen;
 pub use build::{build, cmd_build};
 pub use load::load;
 pub use new::new;

--- a/cargo-bpf/src/lib.rs
+++ b/cargo-bpf/src/lib.rs
@@ -5,6 +5,7 @@
 // http://opensource.org/licenses/MIT>, at your option. This file may not be
 // copied, modified, or distributed except according to those terms.
 
+mod accessors;
 pub mod bindgen;
 mod build;
 mod llvm;

--- a/cargo-bpf/src/main.rs
+++ b/cargo-bpf/src/main.rs
@@ -219,7 +219,7 @@ fn main() {
             .values_of("BINDGEN_ARGS")
             .map(|i| i.collect())
             .unwrap_or_else(Vec::new);
-        if let Err(e) = cargo_bpf::bindgen(&header, &extra_args[..]) {
+        if let Err(e) = cargo_bpf::bindgen::cmd_bindgen(&header, &extra_args[..]) {
             clap::Error::with_description(&e.0, clap::ErrorKind::InvalidValue).exit()
         }
     }

--- a/redbpf-probes/Cargo.toml
+++ b/redbpf-probes/Cargo.toml
@@ -15,8 +15,8 @@ redbpf-macros = { version = "^0.9.9", path = "../redbpf-macros" }
 ufmt = { version = "0.1.0", default-features = false }
 
 [build-dependencies]
-bindgen = "0.51"
 redbpf = { version = "^0.9.9", features = ["build"], path = "../redbpf" }
+cargo-bpf = { version = "^0.9.9", path = "../cargo-bpf" }
 syn = {version = "1.0", features = ["full", "visit", "extra-traits"] }
 quote = "1.0"
 

--- a/redbpf-probes/build.rs
+++ b/redbpf-probes/build.rs
@@ -16,6 +16,7 @@ use syn::{
     ForeignItemStatic, GenericArgument, Ident, PathArguments::*, Type,
 };
 
+use cargo_bpf_lib::bindgen as bpf_bindgen;
 use redbpf::build::headers::kernel_headers;
 
 fn create_module(path: PathBuf, name: &str, bindings: &str) -> io::Result<()> {
@@ -39,46 +40,40 @@ pub use {name}::*;
 
 fn main() {
     let out_dir = PathBuf::from(env::var("OUT_DIR").unwrap());
+    let types = ["pt_regs", "s32", "bpf_.*"];
+    let vars = ["BPF_.*"];
+    let xdp_types = [
+        "xdp_md",
+        "ethhdr",
+        "iphdr",
+        "tcphdr",
+        "udphdr",
+        "xdp_action",
+        "__sk_.*",
+        "sk_.*",
+        "inet_sock",
+    ];
+    let xdp_vars = [
+        "ETH_.*",
+        "IPPROTO_.*",
+        "SOCK_.*",
+        "SK_FL_.*",
+        "AF_.*",
+    ];
 
-    let kernel_headers = kernel_headers().expect("couldn't find kernel headers");
-    let mut flags: Vec<String> = kernel_headers
-        .iter()
-        .map(|dir| format!("-I{}", dir))
-        .collect();
-    flags.extend(redbpf::build::BUILD_FLAGS.iter().map(|f| f.to_string()));
-    flags.push("-Wno-unused-function".to_string());
-    flags.push("-Wno-unused-variable".to_string());
-    flags.push("-Wno-address-of-packed-member".to_string());
-    flags.push("-Wno-gnu-variable-sized-type-not-at-end".to_string());
+    let mut builder = bpf_bindgen::builder().header("./include/redbpf_helpers.h");
 
-    let bindings = bindgen::builder()
-        .clang_args(&flags)
-        .header("./include/redbpf_helpers.h")
-        .use_core()
-        .ctypes_prefix("::cty")
-        // bpf_helpers
-        .whitelist_type("pt_regs")
-        .whitelist_type("s32")
-        .whitelist_type("bpf_.*")
-        .whitelist_var("BPF_.*")
-        // XDP
-        .whitelist_type("xdp_md")
-        .whitelist_type("ethhdr")
-        .whitelist_type("iphdr")
-        .whitelist_type("tcphdr")
-        .whitelist_type("udphdr")
-        .whitelist_type("xdp_action")
-        .whitelist_type("__sk_.*")
-        .whitelist_type("sk_.*")
-        .whitelist_type("inet_sock")
-        .whitelist_var("ETH_.*")
-        .whitelist_var("IPPROTO_.*")
-        .whitelist_var("SOCK_.*")
-        .whitelist_var("SK_FL_.*")
-        .whitelist_var("AF_.*")
-        .opaque_type("xregs_state")
-        .generate()
-        .expect("Unable to generate bindings!");
+    for ty in types.iter().chain(xdp_types.iter()) {
+        builder = builder.whitelist_type(ty);
+    }
+
+    for var in vars.iter().chain(xdp_vars.iter()) {
+        builder = builder.whitelist_var(var);
+    }
+
+    builder = builder.opaque_type("xregs_state");
+    let bindings = builder.generate().expect("failed to generate bindings");
+
     create_module(
         out_dir.join("gen_bindings.rs"),
         "gen_bindings",
@@ -86,10 +81,8 @@ fn main() {
     )
     .unwrap();
 
-    let bindings = bindgen::builder()
-        .clang_args(&flags)
+    let bindings = bpf_bindgen::builder()
         .header("./include/redbpf_helpers.h")
-        .ctypes_prefix("::cty")
         .whitelist_var("bpf_.*")
         .generate()
         .expect("Unable to generate bindings!");


### PR DESCRIPTION
This PR consolidates the bindgen code that used to be scattered between `redbpf-probes` and `cargo-bpf` in `cargo_bpf::bindgen`. Then adds a post processing step that runs on the bindgen output and generates nicer getters that use `bpf_probe_read` internally.

What before was:
```rust
        let dest = bpf_probe_read!(
            &(*socket)
                .__sk_common
                .__bindgen_anon_1
                .__bindgen_anon_1
                .skc_daddr
        );
        let src = bpf_probe_read!(
            &(*socket)
                .__sk_common
                .__bindgen_anon_1
                .__bindgen_anon_1
                .skc_rcv_saddr
        );
```

Now becomes:
```rust
        let dest = socket.skc_daddr();
        let src = socket.skc_rcv_saddr();
```

Finally, `cargo bpf bindgen <header.h>` will now search for `header.h` in the kernel include path if it's not in $PWD, eg:
```
        cargo bpf bindgen net/sock.h # this now works
```