### PR TITLE
redbpf-probes: generate more bpf_probe_read() accessors

### DIFF
--- a/redbpf-probes/build.rs
+++ b/redbpf-probes/build.rs
@@ -71,7 +71,10 @@ fn main() {
         .generate()
         .expect("failed to generate bindings")
         .to_string();
-    let accessors = bpf_bindgen::generate_read_accessors(&bindings, &["sock"]);
+    let accessors = bpf_bindgen::generate_read_accessors(
+        &bindings,
+        &["sock", "file", "inode", "path", "dentry", "qstr"],
+    );
     bindings.push_str("use crate::helpers::bpf_probe_read;");
     bindings.push_str(&accessors);
     create_module(out_dir.join("gen_bindings.rs"), "gen_bindings", &bindings).unwrap();

--- a/redbpf-probes/src/helpers.rs
+++ b/redbpf-probes/src/helpers.rs
@@ -4,7 +4,7 @@ use crate::bindings::*;
 use cty::*;
 pub use ufmt;
 use ufmt::uWrite;
-mod gen {
+pub mod gen {
     include!(concat!(env!("OUT_DIR"), "/gen_helpers.rs"));
 }
 


### PR DESCRIPTION
This change generates accessors for `struct file` and friends