### PR TITLE
Make k(ret)probes take kprobe::Registers as their arg

### DIFF
--- a/redbpf-probes/src/kprobe.rs
+++ b/redbpf-probes/src/kprobe.rs
@@ -40,6 +40,7 @@ pub extern "C" fn enter_execve(ctx: *mut c_void) -> i32 {
 use crate::bindings::*;
 use cty::*;
 
+#[derive(Copy, Clone)]
 pub struct Registers {
     pub ctx: *mut pt_regs,
 }


### PR DESCRIPTION
The original context argument is still available as Registers::ctx