### PR TITLE
XDP improvements

### DIFF
--- a/redbpf-macros/src/lib.rs
+++ b/redbpf-macros/src/lib.rs
@@ -117,7 +117,7 @@ pub fn program(input: TokenStream) -> TokenStream {
             use ::redbpf_probes::helpers::{bpf_trace_printk, TraceMessage, ufmt};
 
             let mut msg = TraceMessage::new();
-            ufmt::uwrite!(&mut msg, "panic in {}\n\0", file!());
+            let _ = ufmt::uwrite!(&mut msg, "panic in {}\n\0", file!());
             msg.printk();
 
             unsafe { core::hint::unreachable_unchecked() }

--- a/redbpf-probes/src/xdp.rs
+++ b/redbpf-probes/src/xdp.rs
@@ -39,7 +39,9 @@ pub extern "C" fn block_port_80(ctx: XdpContext) -> XdpAction {
  */
 use crate::bindings::*;
 use crate::maps::{PerfMap as PerfMapBase, PerfMapFlags};
-use crate::net::NetworkBuffer;
+use crate::net::{NetworkBuffer, NetworkResult};
+
+pub type Result = NetworkResult<XdpAction>;
 
 /// The return type of XDP probes}
 #[repr(u32)]


### PR DESCRIPTION
This PR improves the XDP API so that probes return a `Result`. `redbpf_probes::net` was changed accordingly so now probes can use the `?` operator instead of having to `match` everything.