### PR TITLE
Fixed Typos

### DIFF
--- a/cargo-bpf/src/new_program.rs
+++ b/cargo-bpf/src/new_program.rs
@@ -111,7 +111,7 @@ program!(0xFFFFFFFE, "GPL");
 // #[map("syscall_events")]
 // static mut syscall_events: PerfMap<SomeEvent> = PerfMap::with_max_entries(1024);
 //
-// #[kprobe("syscall_enter")]
+// #[kprobe("do_sys_open")]
 // fn syscall_enter(regs: Registers) {{
 //   let pid_tgid = bpf_get_current_pid_tgid();
 //   ...

--- a/cargo-bpf/src/new_program.rs
+++ b/cargo-bpf/src/new_program.rs
@@ -97,7 +97,7 @@ use cty::*;
 use cty::*;
 
 // use one of the preludes
-// use redbpf_probes::kprobes::prelude::*;
+// use redbpf_probes::kprobe::prelude::*;
 // use redbpf_probes::xdp::prelude::*;
 // use redbpf_probes::socket_filter::prelude::*;
 
@@ -117,10 +117,10 @@ program!(0xFFFFFFFE, "GPL");
 //   ...
 //
 //   let event = SomeEvent {{
-//     id: pid_tgid >> 32,
+//     pid: pid_tgid >> 32,
 //     ...
 //   }};
-//   unsafe {{ syscall_events.insert(ctx, &event) }};
+//   unsafe {{ syscall_events.insert(regs.ctx, &event) }};
 // }}
 "#,
         lib = crate_name,

--- a/cargo-bpf/src/new_program.rs
+++ b/cargo-bpf/src/new_program.rs
@@ -111,7 +111,7 @@ program!(0xFFFFFFFE, "GPL");
 // #[map("syscall_events")]
 // static mut syscall_events: PerfMap<SomeEvent> = PerfMap::with_max_entries(1024);
 //
-// #[kprobe("__x64_do_sys_open")]
+// #[kprobe("sys_open")]
 // fn syscall_enter(regs: Registers) {{
 //   let pid_tgid = bpf_get_current_pid_tgid();
 //   ...

--- a/cargo-bpf/src/new_program.rs
+++ b/cargo-bpf/src/new_program.rs
@@ -111,7 +111,7 @@ program!(0xFFFFFFFE, "GPL");
 // #[map("syscall_events")]
 // static mut syscall_events: PerfMap<SomeEvent> = PerfMap::with_max_entries(1024);
 //
-// #[kprobe("do_sys_open")]
+// #[kprobe("__x64_do_sys_open")]
 // fn syscall_enter(regs: Registers) {{
 //   let pid_tgid = bpf_get_current_pid_tgid();
 //   ...

--- a/cargo-bpf/src/new_program.rs
+++ b/cargo-bpf/src/new_program.rs
@@ -111,7 +111,7 @@ program!(0xFFFFFFFE, "GPL");
 // #[map("syscall_events")]
 // static mut syscall_events: PerfMap<SomeEvent> = PerfMap::with_max_entries(1024);
 //
-// #[kprobe("sys_open")]
+// #[kprobe("__x64_sys_open")]
 // fn syscall_enter(regs: Registers) {{
 //   let pid_tgid = bpf_get_current_pid_tgid();
 //   ...


### PR DESCRIPTION
"cargo bpf add" was providing an example that didn't compile.

Three simple changes fixed it.
kprobes -> kprobe
id -> pid
ctx -> regs.ctx

The default program added by "cargo bpf add" is now able to be compiled.