### PR TITLE
refactor API and add support for uprobes

### DIFF
--- a/cargo-bpf/src/load.rs
+++ b/cargo-bpf/src/load.rs
@@ -7,23 +7,51 @@
 
 use crate::CommandError;
 
-use hexdump::hexdump;
-use redbpf::load::Loader;
-use redbpf::xdp;
-use std::path::PathBuf;
 use futures::stream::StreamExt;
+use hexdump::hexdump;
+use redbpf::xdp;
+use redbpf::{load::Loader, Program::*};
+use std::path::PathBuf;
 use tokio;
 use tokio::runtime::Runtime;
 use tokio::signal;
 
-pub fn load(program: &PathBuf, interface: Option<&str>) -> Result<(), CommandError> {
+pub fn load(
+    program: &PathBuf,
+    interface: Option<&str>,
+) -> Result<(), CommandError> {
     let mut runtime = Runtime::new().unwrap();
-    let _ = runtime.block_on(async {
-        let mut loader = Loader::new()
-            .xdp(interface.map(String::from), xdp::Flags::default())
-            .load_file(&program)
-            .await
-            .expect("error loading file");
+    runtime.block_on(async {
+        // Load all the programs and maps included in the program
+        let mut loader = Loader::load_file(&program).expect("error loading file");
+
+        // attach the programs
+        for program in loader.module.programs.iter_mut() {
+            let name = program.name().to_string();
+            let ret = match program {
+                XDP(prog) => {
+                    let iface = match interface {
+                        Some(i) => i,
+                        None => {
+                            return Err(CommandError(
+                                "XDP program found, but no interface specified".to_string(),
+                            ))
+                        }
+                    };
+                    prog.attach_xdp(&iface, xdp::Flags::default())
+                }
+                KProbe(prog) | KRetProbe(prog) => prog.attach_kprobe(&name, 0),
+                _ => Ok(()),
+            };
+            if let Err(e) = ret {
+                return Err(CommandError(format!(
+                    "failed to attach program {}: {:?}",
+                    name, e
+                )));
+            }
+        }
+
+        // dump all the generated events on stdout
         tokio::spawn(async move {
             while let Some((name, events)) = loader.events.next().await {
                 for event in events {
@@ -33,10 +61,9 @@ pub fn load(program: &PathBuf, interface: Option<&str>) -> Result<(), CommandErr
             }
         });
 
-        signal::ctrl_c().await
-    });
-
-    println!("exiting");
-
-    Ok(())
+        // quit on SIGINT
+        let _ = signal::ctrl_c().await;
+        println!("exiting");
+        Ok(())
+    })
 }

--- a/cargo-bpf/src/main.rs
+++ b/cargo-bpf/src/main.rs
@@ -195,6 +195,12 @@ fn main() {
                             .arg(Arg::with_name("INTERFACE").value_name("INTERFACE").short("i").long("interface").help(
                                 "Binds XDP programs to the given interface"
                             ))
+                            .arg(Arg::with_name("UPROBE_PATH").value_name("PATH").short("u").long("uprobe-path").help(
+                                "Attach uprobes to the given library/binary"
+                            ))
+                            .arg(Arg::with_name("PID").value_name("PID").short("p").long("pid").help(
+                                "Attach uprobes to the given PID"
+                            ))
                             .arg(Arg::with_name("PROGRAM").required(true).help(
                                 "Loads the specified eBPF program and outputs all the events generated",
                             ))
@@ -236,7 +242,9 @@ fn main() {
     if let Some(m) = matches.subcommand_matches("load") {
         let program = m.value_of("PROGRAM").map(PathBuf::from).unwrap();
         let interface = m.value_of("INTERFACE");
-        if let Err(e) = cargo_bpf::load(&program, interface) {
+        let uprobe_path = m.value_of("UPROBE_PATH");
+        let uprobe_pid = m.value_of("PID").map(|p| p.parse::<i32>().unwrap());
+        if let Err(e) = cargo_bpf::load(&program, interface, uprobe_path, uprobe_pid) {
             clap::Error::with_description(&e.0, clap::ErrorKind::InvalidValue).exit()
         }
     }

--- a/redbpf-macros/src/lib.rs
+++ b/redbpf-macros/src/lib.rs
@@ -253,6 +253,44 @@ pub fn kretprobe(attrs: TokenStream, item: TokenStream) -> TokenStream {
     probe_impl("kretprobe", attrs, wrapper, name).into()
 }
 
+/// Attribute macro that must be used to define [`uprobes`](https://www.kernel.org/doc/Documentation/trace/uprobetracer.txt).
+///
+/// # Example
+/// ```no_run
+/// use redbpf_probes::uprobe::prelude::*;
+///
+/// #[uprobe]
+/// fn getaddrinfo(regs: Registers) {
+///     // this is executed when getaddrinfo() is invoked
+/// }
+/// ```
+#[proc_macro_attribute]
+pub fn uprobe(attrs: TokenStream, item: TokenStream) -> TokenStream {
+    let item = parse_macro_input!(item as ItemFn);
+    let name = item.sig.ident.to_string();
+    let wrapper = wrap_kprobe(item);
+    probe_impl("uprobe", attrs, wrapper, name).into()
+}
+
+/// Attribute macro that must be used to define [`uretprobes`](https://www.kernel.org/doc/Documentation/trace/uprobetracer.txt).
+///
+/// # Example
+/// ```no_run
+/// use redbpf_probes::uprobe::prelude::*;
+///
+/// #[uretprobe]
+/// fn getaddrinfo(regs: Registers) {
+///     // this is executed when getaddrinfo() returns
+/// }
+/// ```
+#[proc_macro_attribute]
+pub fn uretprobe(attrs: TokenStream, item: TokenStream) -> TokenStream {
+    let item = parse_macro_input!(item as ItemFn);
+    let name = item.sig.ident.to_string();
+    let wrapper = wrap_kprobe(item);
+    probe_impl("uretprobe", attrs, wrapper, name).into()
+}
+
 /// Attribute macro that must be used to define [`XDP` probes](https://www.iovisor.org/technology/xdp).
 ///
 /// See also the [`XDP` API provided by

--- a/redbpf-probes/src/lib.rs
+++ b/redbpf-probes/src/lib.rs
@@ -56,4 +56,5 @@ pub mod kprobe;
 pub mod maps;
 pub mod net;
 pub mod socket_filter;
+pub mod uprobe;
 pub mod xdp;

--- a/redbpf-probes/src/uprobe/mod.rs
+++ b/redbpf-probes/src/uprobe/mod.rs
@@ -1,0 +1,8 @@
+// Copyright 2019 Authors of Red Sift
+//
+// Licensed under the Apache License, Version 2.0, <LICENSE-APACHE or
+// http://apache.org/licenses/LICENSE-2.0> or the MIT license <LICENSE-MIT or
+// http://opensource.org/licenses/MIT>, at your option. This file may not be
+// copied, modified, or distributed except according to those terms.
+
+pub mod prelude;

--- a/redbpf-probes/src/uprobe/prelude.rs
+++ b/redbpf-probes/src/uprobe/prelude.rs
@@ -1,0 +1,20 @@
+// Copyright 2019-2020 Authors of Red Sift
+//
+// Licensed under the Apache License, Version 2.0, <LICENSE-APACHE or
+// http://apache.org/licenses/LICENSE-2.0> or the MIT license <LICENSE-MIT or
+// http://opensource.org/licenses/MIT>, at your option. This file may not be
+// copied, modified, or distributed except according to those terms.
+//! The Kprobe Prelude
+//!
+//! The purpose of this module is to alleviate imports of the common kprobe types
+//! by adding a glob import to the top of kprobe programs:
+//!
+//! ```
+//! use redbpf_probes::kprobe::prelude::*;
+//! ```
+pub use cty::*;
+pub use redbpf_macros::{uprobe, uretprobe, map, program};
+pub use crate::bindings::*;
+pub use crate::helpers::*;
+pub use crate::maps::*;
+pub use crate::kprobe::*;

--- a/redbpf/src/error.rs
+++ b/redbpf/src/error.rs
@@ -16,6 +16,9 @@ pub enum Error {
     IO(::std::io::Error),
     Uname,
     Reloc,
+    SymbolNotFound(String),
+    ProgramAlreadyLoaded,
+    ProgramNotLoaded
 }
 
 pub type Result<T> = ::std::result::Result<T, Error>;

--- a/redbpf/src/load/loader.rs
+++ b/redbpf/src/load/loader.rs
@@ -13,7 +13,7 @@ use std::path::Path;
 
 use crate::cpus;
 use crate::load::map_io::PerfMessageStream;
-use crate::{Error, KProbe, Map, Module, PerfMap, SocketFilter, XDP};
+use crate::{Error, KProbe, Map, Module, PerfMap, SocketFilter, UProbe, XDP};
 
 #[derive(Debug)]
 pub enum LoaderError {
@@ -102,6 +102,10 @@ impl Loaded {
 
     pub fn kprobes_mut(&mut self) -> impl Iterator<Item = &mut KProbe> {
         self.module.kprobes_mut()
+    }
+
+    pub fn uprobes_mut(&mut self) -> impl Iterator<Item = &mut UProbe> {
+        self.module.uprobes_mut()
     }
 
     pub fn xdps_mut(&mut self) -> impl Iterator<Item = &mut XDP> {

--- a/redbpf/src/load/loader.rs
+++ b/redbpf/src/load/loader.rs
@@ -5,75 +5,39 @@
 // http://opensource.org/licenses/MIT>, at your option. This file may not be
 // copied, modified, or distributed except according to those terms.
 
-use bpf_sys;
 use futures::channel::mpsc;
 use futures::prelude::*;
-use std::ffi::CString;
 use std::fs;
 use std::io;
 use std::path::Path;
 
 use crate::cpus;
 use crate::load::map_io::PerfMessageStream;
-use crate::ProgramKind::*;
-use crate::{xdp, Error, Module, PerfMap};
+use crate::{Error, KProbe, Map, Module, PerfMap, SocketFilter, XDP};
 
 #[derive(Debug)]
 pub enum LoaderError {
     FileError(io::Error),
     ParseError(Error),
     LoadError(String, Error),
-    XdpError(String, Error),
-    KprobeError(String, Error),
 }
 
 /// High level API to load bpf programs.
-pub struct Loader {
-    xdp: XdpConfig,
-}
+pub struct Loader {}
 
 impl Loader {
-    /// Creates a new loader.
-    pub fn new() -> Self {
-        Loader {
-            xdp: XdpConfig::default(),
-        }
-    }
-
-    /// Sets the network interface and flags for XDP programs.
-    pub fn xdp(&mut self, interface: Option<String>, flags: xdp::Flags) -> &mut Self {
-        self.xdp = XdpConfig { interface, flags };
-        self
-    }
-
     /// Loads the programs included in `data`.
     ///
     /// This will parse `data` with `Module::parse()` and load all the programs
     /// present in the module.
-    pub async fn load(&self, data: &[u8]) -> Result<Loaded, LoaderError> {
+    pub fn load(data: &[u8]) -> Result<Loaded, LoaderError> {
         let mut module = Module::parse(&data).map_err(|e| LoaderError::ParseError(e))?;
-        for prog in module.programs.iter_mut() {
-            prog.load(module.version, module.license.clone())
-                .map_err(|e| LoaderError::LoadError(prog.name.clone(), e))?;
+        for program in module.programs.iter_mut() {
+            program
+                .load(module.version, module.license.clone())
+                .map_err(|e| LoaderError::LoadError(program.name().to_string(), e))?;
         }
 
-        if let Some(interface) = &self.xdp.interface {
-            for prog in module.programs.iter_mut().filter(|p| p.kind == XDP) {
-                println!("Loaded: {}, {:?}", prog.name, prog.kind);
-                prog.attach_xdp(&interface, self.xdp.flags)
-                    .map_err(|e| LoaderError::XdpError(prog.name.clone(), e))?;
-            }
-        }
-
-        for prog in module
-            .programs
-            .iter_mut()
-            .filter(|p| p.kind == Kprobe || p.kind == Kretprobe)
-        {
-            prog.attach_probe()
-                .map_err(|e| LoaderError::KprobeError(prog.name.clone(), e))?;
-            println!("Loaded: {}, {:?}", prog.name, prog.kind);
-        }
         let online_cpus = cpus::get_online().unwrap();
         let (sender, receiver) = mpsc::unbounded();
         for m in module.maps.iter_mut().filter(|m| m.kind == 4) {
@@ -92,7 +56,6 @@ impl Loader {
 
         Ok(Loaded {
             module,
-            xdp: self.xdp.clone(),
             events: receiver,
         })
     }
@@ -100,16 +63,14 @@ impl Loader {
     /// Loads the BPF programs included in `file`.
     ///
     /// See `load()`.
-    pub async fn load_file(&self, file: &Path) -> Result<Loaded, LoaderError> {
-        self.load(&fs::read(file).map_err(|e| LoaderError::FileError(e))?)
-            .await
+    pub fn load_file(file: &Path) -> Result<Loaded, LoaderError> {
+        Loader::load(&fs::read(file).map_err(|e| LoaderError::FileError(e))?)
     }
 }
 
 /// The `Loaded` object returned by `load()`.
 pub struct Loaded {
     pub module: Module,
-    xdp: XdpConfig,
     /// The stream of events emitted by the BPF programs.
     ///
     /// # Example
@@ -119,7 +80,7 @@ pub struct Loaded {
     /// use futures::stream::StreamExt;
     /// use redbpf::load::Loader;
     /// # async {
-    /// let mut loader = Loader::new().load_file(&Path::new("probe.elf")).await.unwrap();
+    /// let mut loader = Loader::load_file(&Path::new("probe.elf")).unwrap();
     /// while let Some((map_name, events)) = loader.events.next().await {
     ///     for event in events {
     ///         // ...
@@ -130,26 +91,24 @@ pub struct Loaded {
     pub events: mpsc::UnboundedReceiver<(String, <PerfMessageStream as Stream>::Item)>,
 }
 
-impl Drop for Loaded {
-    fn drop(&mut self) {
-        if let Some(interface) = &self.xdp.interface {
-            let ciface = CString::new(interface.as_bytes()).unwrap();
-            let _ = unsafe { bpf_sys::bpf_attach_xdp(ciface.as_ptr(), -1, 0) };
-        }
+impl Loaded {
+    pub fn map(&self, name: &str) -> Option<&Map> {
+        self.module.maps.iter().find(|m| m.name == name)
     }
-}
 
-#[derive(Debug, Clone)]
-pub struct XdpConfig {
-    interface: Option<String>,
-    flags: xdp::Flags,
-}
+    pub fn map_mut(&mut self, name: &str) -> Option<&mut Map> {
+        self.module.maps.iter_mut().find(|m| m.name == name)
+    }
 
-impl Default for XdpConfig {
-    fn default() -> XdpConfig {
-        XdpConfig {
-            interface: None,
-            flags: xdp::Flags::default(),
-        }
+    pub fn kprobes_mut(&mut self) -> impl Iterator<Item = &mut KProbe> {
+        self.module.kprobes_mut()
+    }
+
+    pub fn xdps_mut(&mut self) -> impl Iterator<Item = &mut XDP> {
+        self.module.xdps_mut()
+    }
+
+    pub fn socket_filters_mut(&mut self) -> impl Iterator<Item = &mut SocketFilter> {
+        self.module.socket_filters_mut()
     }
 }


### PR DESCRIPTION
This PR refactors the low level redbpf bits, `redbpf::Loader` and finally adds support for uprobes.

The main refactoring consists in removing `ProgramKind` and making `Program` an enum with a variant for each probe type. In addition to being more idiomatic, the new API makes it impossible to call the wrong attach_* methods. With the old API it was in fact possible to call `attach_xdp()` or `attach_socketfilter()` for a `kprobe` program, which was obviously wrong.  With the new API that'd result in a compilation error.

`redbpf::load::Loader` was refactored too. The builder pattern is out and the API now exports a consistent interface for all program types. The simplest kprobe loader now is something like:

```
let mut loader = Loader::load_file("example.elf").unwrap();
for kprobe in loader.kprobes_mut() {
    kprobe.attach_kprobe(&kprobe.name(), 0).unwrap();
}
```

And the simplest XDP loader would be:

```
let mut loader = Loader::load("example.elf").unwrap();
for prog in loader.xdps_mut() {
    prog.attach_xdp("eth0", xdp::Flags::default()).unwrap();
}
```