### PR TITLE
Upgrade to LLVM 10

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,7 +52,7 @@ project](https://github.com/redsift/ingraind/tree/v1.0).
 In order to build some of the code here, you will need the following:
 
  * Linux 4.19+, with a build tree. The build tree is picked up from standard locations, or the `KERNEL_SOURCE` environment variable.
- * LLVM 9, or an LLVM version compatible with the Rust release you're using to build
+ * LLVM 10
  * The latest stable Rust compiler. We only promise to build with the latest stable and nightly compilers.
 
 # Getting started
@@ -70,7 +70,6 @@ sure you sync the git submodules necessary to build redbpf:
 
 Then install the dependencies for your distro before running the usual ritual.
 
-	cargo build --release
     cargo install --path cargo-bpf
 
 ## Ubuntu
@@ -82,19 +81,20 @@ Install the following dependencies:
 		gnupg2 \
 		software-properties-common \
 		build-essential \
-		clang-9 \
-		llvm-9 \
+		clang-10 \
+		llvm-10 \
 		libelf-dev \
-		linux-headers \
-		ca-certificates{,-java}
+		linux-headers-$(uname -r) \
+		zlib1g \
+		ca-certificates
 
 ## Fedora
 
-	yum install -y clang-9.0.0 \
-		llvm-9.0.0 \
-		llvm-libs-9.0.0 \
-		llvm-devel-9.0.0 \
-		llvm-static-9.0.0 \
+	yum install -y clang-10.0.0 \
+		llvm-10.0.0 \
+		llvm-libs-10.0.0 \
+		llvm-devel-10.0.0 \
+		llvm-static-10.0.0 \
 		kernel \
 		kernel-devel \
 		elfutils-libelf-devel \

--- a/cargo-bpf/Cargo.toml
+++ b/cargo-bpf/Cargo.toml
@@ -23,7 +23,7 @@ futures = { version = "0.3", optional = true }
 tokio = { version = "0.2.4", features = ["rt-core", "io-driver", "macros", "signal"], optional = true }
 hexdump = { version = "0.1", optional = true }
 libc = "0.2.66"
-llvm-sys = "90"
+llvm-sys = "100"
 syn = { version = "1.0", features = ["full", "visit"] }
 quote = "1.0"
 proc-macro2 = "1.0"

--- a/cargo-bpf/src/build.rs
+++ b/cargo-bpf/src/build.rs
@@ -287,12 +287,12 @@ fn probe_names(doc: &Document) -> Result<Vec<String>, Error> {
 }
 
 fn get_opt_executable() -> Result<String, Error> {
-    for llc in vec!["opt".into(), env::var("OPT").unwrap_or("opt-9".into())].drain(..) {
-        if let Ok(out) = Command::new(&llc).arg("--version").output() {
+    for opt in vec!["opt".into(), env::var("OPT").unwrap_or("opt-10".into())].drain(..) {
+        if let Ok(out) = Command::new(&opt).arg("--version").output() {
             match String::from_utf8(out.stdout) {
                 Ok(out) => {
-                    if out.contains("LLVM version 9.") {
-                        return Ok(llc);
+                    if out.contains("LLVM version 10.") {
+                        return Ok(opt);
                     }
                 }
                 Err(_) => continue,
@@ -304,11 +304,11 @@ fn get_opt_executable() -> Result<String, Error> {
 }
 
 pub(crate) fn get_llc_executable() -> Result<String, Error> {
-    for llc in vec!["llc".into(), env::var("LLC").unwrap_or("llc-9".into())].drain(..) {
+    for llc in vec!["llc".into(), env::var("LLC").unwrap_or("llc-10".into())].drain(..) {
         if let Ok(out) = Command::new(&llc).arg("--version").output() {
             match String::from_utf8(out.stdout) {
                 Ok(out) => {
-                    if out.contains("LLVM version 9.") {
+                    if out.contains("LLVM version 10.") {
                         return Ok(llc);
                     }
                 }


### PR DESCRIPTION
(Forgot to mention the reasoning, [Rust 1.45 is using LLVM 10 now](https://github.com/rust-lang/rust/commit/82911b3bba76e73afe2881b732fe6b0edb35d5d3) which is the merge commit from [this PR](https://github.com/rust-lang/rust/pull/67759))

The code change should be trivial.

I think we might want to clean up the README a bit, for Ubuntu dependencies:

- Don't think we need `curl` `wget` or `gnupg2` at all?
- Don't think we need `ca-certificates-java` either?
- It seems `libelf` is enough (I just realized I didn't have `libelf-dev` - though installing it doesn't solve the load issue I have, and it certainly didn't affect `cargo bpf build`)
- `zlib1g` is needed (forgot about the error message but it's the first error I hit when running `cargo bpf build`)
- `linux-headers` need to pick an explicit version, otherwise `apt` (`apt-get` too) complains `E: Package 'linux-headers' has no installation candidate`

It might also be related to Ubuntu releases, I'm running on 20.04 (Desktop).