### PR TITLE
cargo-bpf: fix for rustc >= 1.45

### DIFF
--- a/cargo-bpf/src/build.rs
+++ b/cargo-bpf/src/build.rs
@@ -135,8 +135,15 @@ fn build_probe(cargo: &Path, package: &Path, target_dir: &Path, probe: &str) -> 
     let _ = fs::remove_dir_all(&artifacts_dir);
     fs::create_dir_all(&artifacts_dir)?;
 
+    let mut flags = String::new();
+    if let Ok(rf) = std::env::var("RUSTFLAGS") {
+        flags.push_str(&rf);
+    }
+    flags.push_str(" -C embed-bitcode=yes");
+
     if !Command::new(cargo)
         .current_dir(package)
+        .env("RUSTFLAGS", flags)
         .args("rustc --release --features=probes".split(" "))
         .arg("--target-dir")
         .arg(target_dir.to_str().unwrap())


### PR DESCRIPTION
Since version 1.45, rustc no longer produces bitcode for crates by default. We need bitcode to turn on LTO, so pass -C embed-bitcode=yes to the compiler.

We must pass it in RUSTFLAGS since we need bitcode for all crates, while the flags passed as cargo rustc args only apply to the main crate.