### PR TITLE
cargo-bpf: load: don't unload programs too early

### DIFF
--- a/cargo-bpf/src/load.rs
+++ b/cargo-bpf/src/load.rs
@@ -7,7 +7,7 @@
 
 use crate::CommandError;
 
-use futures::stream::StreamExt;
+use futures::{future, stream::StreamExt};
 use hexdump::hexdump;
 use redbpf::xdp;
 use redbpf::{load::Loader, Program::*};
@@ -72,6 +72,11 @@ pub fn load(
                     hexdump(&event);
                 }
             }
+
+            // If the program doesn't have any maps and therefore doesn't fire any events, we still
+            // need to keep `loader` alive here so that BPF programs are not dropped. The future
+            // below will never complete, meaning that the programs will keep running until Ctrl-C
+            future::pending::<()>().await;
         });
 
         // quit on SIGINT


### PR DESCRIPTION
This PR fixes a bug where the loader would accidentally get dropped early for programs that don't submit any events, causing programs to get unloaded.

Example program that used to trigger the bug:

```rust
#![no_std]
#![no_main]
use redbpf_probes::xdp::prelude::*;

program!(0xFFFFFFFE, "GPL");

#[xdp("block_port")]
pub fn block_port(ctx: XdpContext) -> XdpResult {
    match ctx.transport()? {
        t @ Transport::TCP(_) if t.dest() == 1111 => Ok(XdpAction::Drop),
        _ => return Ok(XdpAction::Pass),
    }
```