### PR TITLE
Improve the CI process

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -15,22 +15,18 @@ jobs:
         type: string
         default: "latest"
     working_directory: /build
+    resource_class: large
     docker:
       - image: quay.io/redsift/ingraind-build:<< parameters.tag >>
     steps:
       - setup_ubuntu_env
       - run:
-          name: Configure env vars
+          name: Build
           command: |
             export KERNEL_SOURCE=/usr/src/kernels/$(rpm -qa kernel-devel || true |cut -d- -f3-)/
             if [ "x$KERNEL_SOURCE" = "x/usr/src/kernels//" ]; then
-                export KERNEL_SOURCE=/lib/modules/$(ls /lib/modules |head -n1)
+                export KERNEL_SOURCE=/lib/modules/$(ls /lib/modules |head -n1)/build/
             fi
-            echo export KERNEL_SOURCE="$KERNEL_SOURCE" |tee $BASH_ENV
-            echo export LLC=llc |tee $BASH_ENV
-      - run:
-          name: Build
-          command: |
             cargo build
             cargo test --bins --tests
             RUSTDOCFLAGS="-C panic=abort" cargo test --doc --workspace src

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -22,7 +22,7 @@ jobs:
       - run:
           name: Configure env vars
           command: |
-            export KERNEL_SOURCE=/usr/src/kernels/$(rpm -qa kernel-devel |cut -d- -f3-)/ 
+            export KERNEL_SOURCE=/usr/src/kernels/$(rpm -qa kernel-devel || true |cut -d- -f3-)/
             if [ -z "$KERNEL_SOURCE" ]; then
                 export KERNEL_SOURCE=/lib/modules/$(ls /lib/modules |head -n1)
             fi

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -23,7 +23,7 @@ jobs:
       - run:
           name: Build
           command: |
-            export KERNEL_SOURCE=/usr/src/kernels/$(rpm -qa kernel-devel || true |cut -d- -f3-)/
+            export KERNEL_SOURCE=/usr/src/kernels/$(rpm -qa kernel-devel |cut -d- -f3- || true)/
             if [ "x$KERNEL_SOURCE" = "x/usr/src/kernels//" ]; then
                 export KERNEL_SOURCE=/lib/modules/$(ls /lib/modules |head -n1)/build/
             fi

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -26,9 +26,8 @@ jobs:
             if [ -z "$KERNEL_SOURCE" ]; then
                 export KERNEL_SOURCE=/lib/modules/$(ls /lib/modules |head -n1)
             fi
-            echo export KERNEL_SOURCE="$KERNEL_SOURCE">> $BASH_ENV
-            echo export LLC=llc >> $BASH_ENV
-            echo unset RUSTC_WRAPPER >> $BASH_ENV
+            echo export KERNEL_SOURCE="$KERNEL_SOURCE" |tee $BASH_ENV
+            echo export LLC=llc |tee $BASH_ENV
       - run:
           name: Build
           command: |

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,4 +1,4 @@
-image: &default_image quay.io/redsift/ingraind-build:19.10
+image: &default_image quay.io/redsift/ingraind-build:20.04
 
 version: 2.1
 commands:
@@ -9,7 +9,7 @@ commands:
       - run: git submodule update --init
 
 jobs:
-  build_ubuntu:
+  build_doc_and_bin:
     parameters:
       tag:
         type: string
@@ -19,6 +19,16 @@ jobs:
       - image: quay.io/redsift/ingraind-build:<< parameters.tag >>
     steps:
       - setup_ubuntu_env
+      - run:
+          name: Configure env vars
+          command: |
+            export KERNEL_SOURCE=/usr/src/kernels/$(rpm -qa kernel-devel |cut -d- -f3-)/ 
+            if [ -z "$KERNEL_SOURCE" ]; then
+                export KERNEL_SOURCE=/lib/modules/$(ls /lib/modules |head -n1)
+            fi
+            echo export KERNEL_SOURCE="$KERNEL_SOURCE">> $BASH_ENV
+            echo export LLC=llc >> $BASH_ENV
+            echo unset RUSTC_WRAPPER >> $BASH_ENV
       - run:
           name: Build
           command: |
@@ -63,17 +73,24 @@ workflows:
   version: 2
   build_publish:
     jobs:
-      - build_ubuntu:
+      - build_doc_and_bin:
           context: org-global
           name: "ubuntu 18.04"
           tag: "18.04"
           filters:
             tags:
               only: /.*/
-      - build_ubuntu:
+      - build_doc_and_bin:
           context: org-global
-          name: "ubuntu 19.10"
-          tag: "19.10"
+          name: "ubuntu 20.04"
+          tag: "20.04"
+          filters:
+            tags:
+              only: /.*/
+      - build_doc_and_bin:
+          context: org-global
+          name: "fedora 32"
+          tag: "fedora"
           filters:
             tags:
               only: /.*/
@@ -81,7 +98,8 @@ workflows:
           context: org-global
           requires:
             - "ubuntu 18.04"
-            - "ubuntu 19.10"
+            - "ubuntu 20.04"
+            - "fedora 32"
           filters:
             tags:
               only: /^v.*/

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -23,7 +23,7 @@ jobs:
           name: Configure env vars
           command: |
             export KERNEL_SOURCE=/usr/src/kernels/$(rpm -qa kernel-devel || true |cut -d- -f3-)/
-            if [ -z "$KERNEL_SOURCE" ]; then
+            if [ "x$KERNEL_SOURCE" = "x/usr/src/kernels//" ]; then
                 export KERNEL_SOURCE=/lib/modules/$(ls /lib/modules |head -n1)
             fi
             echo export KERNEL_SOURCE="$KERNEL_SOURCE" |tee $BASH_ENV


### PR DESCRIPTION
This PR will use an updated set of builders, and adds support for Ubuntu 20.04 and Fedora 32 in the CI. Using the base kernels in each distro means we get a wider coverage than before.