### PR TITLE
Fix build on RH kernels

### DIFF
--- a/bpf-sys/Cargo.toml
+++ b/bpf-sys/Cargo.toml
@@ -16,5 +16,5 @@ libc = "0.2"
 
 [build-dependencies]
 cc = "1.0"
-bindgen = "0.51"
+bindgen = "0.55"
 libc = "0.2"

--- a/cargo-bpf/Cargo.toml
+++ b/cargo-bpf/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cargo-bpf"
-version = "1.1.1"
+version = "1.1.2"
 description = "Cargo plugin to manage eBPF probes using redbpf"
 repository = "https://github.com/redsift/redbpf"
 documentation = "https://ingraind.org/api//cargo_bpf/"
@@ -14,15 +14,15 @@ license = "MIT OR Apache-2.0"
 name = "cargo_bpf_lib"
 
 [dependencies]
-clap = { version = "2.33", optional = true }
-bindgen = "0.51.1"
-toml_edit = "0.1.5"
+clap = { version = "^2.33", optional = true }
+bindgen = "0.55"
+toml_edit = "0.2"
 bpf-sys = { version = "^1.1.1", path = "../bpf-sys" }
 redbpf = { version = "^1.1.0", path = "../redbpf", default-features = false, optional = true }
 futures = { version = "0.3", optional = true }
-tokio = { version = "0.2.4", features = ["rt-core", "io-driver", "macros", "signal"], optional = true }
+tokio = { version = "^0.2.4", features = ["rt-core", "io-driver", "macros", "signal"], optional = true }
 hexdump = { version = "0.1", optional = true }
-libc = "0.2.66"
+libc = "^0.2.66"
 llvm-sys = "100"
 syn = { version = "1.0", features = ["full", "visit"] }
 quote = "1.0"

--- a/redbpf-tools/Cargo.toml
+++ b/redbpf-tools/Cargo.toml
@@ -10,6 +10,6 @@ cargo-bpf = { version = "^1.1.0", path = "../cargo-bpf", default-features = fals
 [dependencies]
 probes = { path = "./probes" }
 redbpf = {  version = "^1.1.0", path = "../redbpf", features = ["load"] }
-tokio = { version = "0.2.4", features = ["rt-core", "io-driver", "macros", "signal", "time"] }
+tokio = { version = "^0.2.4", features = ["rt-core", "io-driver", "macros", "signal", "time"] }
 futures = "0.3"
 getopts = "0.2"

--- a/redbpf/Cargo.toml
+++ b/redbpf/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "redbpf"
-version = "1.1.0"
+version = "1.1.2"
 description = "eBPF build and runtime library"
 repository = "https://github.com/redsift/redbpf"
 documentation = "https://ingraind.org/api//redbpf/"
@@ -19,7 +19,7 @@ bpf-sys = { path = "../bpf-sys", version = "^1.1.0" }
 goblin = "0.2"
 zero = "0.1"
 libc = "0.2"
-bindgen = "0.51"
+bindgen = "0.55"
 regex = "1.0"
 lazy_static = "1.0"
 byteorder = "1"
@@ -30,7 +30,7 @@ ring = { version = "0.16", optional = true }
 
 futures = { version = "0.3", optional = true }
 mio = { version = "0.6", optional = true }
-tokio = { version = "0.2.4", features = ["rt-core", "io-driver", "macros", "signal"], optional = true }
+tokio = { version = "^0.2.4", features = ["rt-core", "io-driver", "macros", "signal"], optional = true }
 
 [features]
 default = []

--- a/redbpf/src/lib.rs
+++ b/redbpf/src/lib.rs
@@ -800,7 +800,7 @@ impl<K: Clone, V: Clone> Iterator for MapIter<'_, '_, K, V> {
                     bpf_sys::bpf_get_first_key(
                         self.map.base.fd,
                         &mut key as *mut _ as *mut _,
-                        self.map.base.config.key_size as usize,
+                        self.map.base.config.key_size.into(),
                     )
                 } < 0
                 {


### PR DESCRIPTION
RedHat patches their kernels (apparently including Fedora) in a way that messes with the attribute accessor generation logic in `cargo-bpf`. Since I first assumed this was a bug with headers and build environment, I took the reasonable first step of upgrading `bindgen` and some other dependencies, so this PR includes those, too.