### PR TITLE
cargo-bpf: add slimmed down bindings feature to improve compile times

### DIFF
--- a/cargo-bpf/Cargo.toml
+++ b/cargo-bpf/Cargo.toml
@@ -13,25 +13,30 @@ license = "MIT OR Apache-2.0"
 [lib]
 name = "cargo_bpf_lib"
 
+[[bin]]
+name = "cargo-bpf"
+required-features = ["command-line"]
+
 [dependencies]
-clap = { version = "^2.33", optional = true }
-bindgen = "0.55"
-toml_edit = "0.2"
-bpf-sys = { version = "^1.1.2", path = "../bpf-sys" }
+clap = { version = "2.33", optional = true }
+bindgen = { version = "0.55", optional = true }
+toml_edit = { version = "0.2", optional = true }
+bpf-sys = { version = "^1.1.2", path = "../bpf-sys", optional = true }
 redbpf = { version = "^1.1.2", path = "../redbpf", default-features = false, optional = true }
 futures = { version = "0.3", optional = true }
 tokio = { version = "^0.2.4", features = ["rt-core", "io-driver", "macros", "signal"], optional = true }
 hexdump = { version = "0.1", optional = true }
-libc = "^0.2.66"
-llvm-sys = "100"
-syn = { version = "1.0", features = ["full", "visit"] }
-quote = "1.0"
-proc-macro2 = "1.0"
-tempfile = "3.1"
+libc = {version = "0.2.66", optional = true}
+llvm-sys = { version = "100", optional = true}
+syn = { version = "1.0", features = ["full", "visit"], optional = true }
+quote = { version = "1.0", optional = true }
+proc-macro2 = {version = "1.0", optional = true}
+tempfile = { version = "3.1", optional = true}
 lazy_static = "1.0"
 
 [features]
 default = ["command-line"]
-build = []
+bindings = ["bpf-sys", "bindgen", "syn", "quote", "proc-macro2", "tempfile"]
+build = ["bindings", "libc", "toml_edit", "llvm-sys"]
 build-c = []
-command-line = ["clap", "redbpf/load", "futures", "tokio", "hexdump"]
+command-line = ["build", "clap", "redbpf/load", "futures", "tokio", "hexdump"]

--- a/cargo-bpf/src/bindgen.rs
+++ b/cargo-bpf/src/bindgen.rs
@@ -14,7 +14,7 @@ use std::str;
 use tempfile;
 
 pub use crate::accessors::generate_read_accessors;
-use crate::build::{kernel_headers, BUILD_FLAGS};
+use crate::build_constants::{kernel_headers, BUILD_FLAGS};
 use crate::CommandError;
 
 pub fn builder() -> Builder {

--- a/cargo-bpf/src/build.rs
+++ b/cargo-bpf/src/build.rs
@@ -5,8 +5,7 @@
 // http://opensource.org/licenses/MIT>, at your option. This file may not be
 // copied, modified, or distributed except according to those terms.
 
-use bpf_sys::headers::{prefix_kernel_headers, build_kernel_version};
-use lazy_static::lazy_static;
+use bpf_sys::headers::build_kernel_version;
 use std::convert::From;
 use std::env;
 use std::fmt::{self, Display};
@@ -30,63 +29,6 @@ pub enum Error {
     MissingBitcode(String),
     Link(String),
     IOError(io::Error),
-}
-
-#[cfg(target_arch = "x86_64")]
-const KERNEL_HEADERS: [&str; 7] = [
-    "arch/x86/include",
-    "arch/x86/include/generated",
-    "include",
-    "include/generated",
-    "arch/include/generated/uapi",
-    "arch/x86/include/uapi",
-    "include/uapi",
-];
-
-#[cfg(target_arch = "aarch64")]
-const KERNEL_HEADERS: [&str; 8] = [
-    "arch/arm64/include",
-    "arch/arm64/include/generated",
-    "include",
-    "include/generated",
-    "arch/include/generated/uapi",
-    "arch/arm64/include/uapi",
-    "arch/arm64/include/generated/uapi",
-    "include/uapi",
-];
-
-lazy_static! {
-    pub(crate) static ref BUILD_FLAGS: Vec<&'static str> = {
-        let mut flags = vec![
-            "-D__BPF_TRACING__",
-            "-D__KERNEL__",
-            "-Wall",
-            "-Werror",
-            "-Wunused",
-            "-Wno-unused-value",
-            "-Wno-pointer-sign",
-            "-Wno-compare-distinct-pointer-types",
-            "-Wno-unused-parameter",
-            "-Wno-missing-field-initializers",
-            "-Wno-initializer-overrides",
-            "-Wno-unknown-pragmas",
-            "-fno-stack-protector",
-            "-Wno-unused-label",
-            "-Wno-unused-variable",
-            "-Wno-unused-function",
-            "-Wno-address-of-packed-member",
-            "-Wno-gnu-variable-sized-type-not-at-end",
-        ];
-
-        if cfg!(x86_64) {
-            flags.push("-D__ASM_SYSREG_H");
-        } else if cfg!(aarch64) {
-            flags.push("-target");
-            flags.push("aarch64");
-        }
-
-        flags
-    };
 }
 
 impl std::error::Error for Error {
@@ -337,8 +279,4 @@ pub(crate) fn get_llc_executable() -> Result<String, Error> {
     }
 
     return Err(Error::NoLLC);
-}
-
-pub(crate) fn kernel_headers() -> Result<Vec<String>, ()> {
-    prefix_kernel_headers(&KERNEL_HEADERS).ok_or(())
 }

--- a/cargo-bpf/src/build_constants.rs
+++ b/cargo-bpf/src/build_constants.rs
@@ -1,0 +1,63 @@
+use bpf_sys::headers::prefix_kernel_headers;
+use lazy_static::lazy_static;
+
+#[cfg(target_arch = "x86_64")]
+pub(crate) const KERNEL_HEADERS: [&str; 7] = [
+    "arch/x86/include",
+    "arch/x86/include/generated",
+    "include",
+    "include/generated",
+    "arch/include/generated/uapi",
+    "arch/x86/include/uapi",
+    "include/uapi",
+];
+
+#[cfg(target_arch = "aarch64")]
+pub(crate) const KERNEL_HEADERS: [&str; 8] = [
+    "arch/arm64/include",
+    "arch/arm64/include/generated",
+    "include",
+    "include/generated",
+    "arch/include/generated/uapi",
+    "arch/arm64/include/uapi",
+    "arch/arm64/include/generated/uapi",
+    "include/uapi",
+];
+
+lazy_static! {
+    pub(crate) static ref BUILD_FLAGS: Vec<&'static str> = {
+        let mut flags = vec![
+            "-D__BPF_TRACING__",
+            "-D__KERNEL__",
+            "-Wall",
+            "-Werror",
+            "-Wunused",
+            "-Wno-unused-value",
+            "-Wno-pointer-sign",
+            "-Wno-compare-distinct-pointer-types",
+            "-Wno-unused-parameter",
+            "-Wno-missing-field-initializers",
+            "-Wno-initializer-overrides",
+            "-Wno-unknown-pragmas",
+            "-fno-stack-protector",
+            "-Wno-unused-label",
+            "-Wno-unused-variable",
+            "-Wno-unused-function",
+            "-Wno-address-of-packed-member",
+            "-Wno-gnu-variable-sized-type-not-at-end",
+        ];
+
+        if cfg!(x86_64) {
+            flags.push("-D__ASM_SYSREG_H");
+        } else if cfg!(aarch64) {
+            flags.push("-target");
+            flags.push("aarch64");
+        }
+
+        flags
+    };
+}
+
+pub(crate) fn kernel_headers() -> Result<Vec<String>, ()> {
+    prefix_kernel_headers(&KERNEL_HEADERS).ok_or(())
+}

--- a/cargo-bpf/src/lib.rs
+++ b/cargo-bpf/src/lib.rs
@@ -4,13 +4,20 @@
 // http://apache.org/licenses/LICENSE-2.0> or the MIT license <LICENSE-MIT or
 // http://opensource.org/licenses/MIT>, at your option. This file may not be
 // copied, modified, or distributed except according to those terms.
+mod build_constants;
 
+#[cfg(feature = "bindings")]
 mod accessors;
+#[cfg(feature = "bindings")]
 pub mod bindgen;
+
+#[cfg(feature = "build")]
 mod build;
+#[cfg(feature = "build")]
+mod llvm;
 #[cfg(feature = "build-c")]
 mod build_c;
-mod llvm;
+
 #[cfg(feature = "command-line")]
 mod load;
 #[cfg(feature = "command-line")]
@@ -26,6 +33,7 @@ impl std::convert::From<std::io::Error> for CommandError {
     }
 }
 
+#[cfg(feature = "build")]
 pub use build::*;
 #[cfg(feature = "build-c")]
 pub use build_c::*;

--- a/cargo-bpf/src/new.rs
+++ b/cargo-bpf/src/new.rs
@@ -35,7 +35,7 @@ redbpf-macros = "1.0"
 redbpf-probes = "1.0"
 
 [build-dependencies]
-cargo-bpf = "1.0"
+cargo-bpf = {{ version = "1.0", default-features = false }}
 
 [features]
 default = []

--- a/redbpf-probes/Cargo.toml
+++ b/redbpf-probes/Cargo.toml
@@ -15,7 +15,7 @@ redbpf-macros = { version = "^1.0.1", path = "../redbpf-macros" }
 ufmt = { version = "0.1.0", default-features = false }
 
 [build-dependencies]
-cargo-bpf = { version = "^1.1.0", path = "../cargo-bpf", default-features = false, features = ["build"] }
+cargo-bpf = { version = "^1.1.0", path = "../cargo-bpf", default-features = false, features = ["bindings"] }
 syn = {version = "1.0", default-features = false, features = ["parsing", "visit"] }
 quote = "1.0"
 

--- a/redbpf-tools/probes/Cargo.toml
+++ b/redbpf-tools/probes/Cargo.toml
@@ -4,7 +4,7 @@ version = "0.1.0"
 edition = '2018'
 
 [build-dependencies]
-cargo-bpf = { version = "^1.1.0", path = "../../cargo-bpf", default-features = false, features = ["build"] }
+cargo-bpf = { version = "^1.1.0", path = "../../cargo-bpf", default-features = false, features = ["bindings"] }
 
 [dependencies]
 cty = "0.2"


### PR DESCRIPTION
I've been working on improving compile times.

This PR adds a bindings feature that depends on the minimal set of deps required to run cargo_bpf::bindgen::*. In their build.rs, probes commonly just need to generate bindings for kernel/user headers, so this improves compile times significantly.

Here's the time compiling redbpf-tools before:
```
  Time Crate
17.63s toml_edit
13.45s redbpf_probes
12.92s combine
 9.93s syn
 9.89s bindgen
 7.83s clap
 7.03s clang_sys
 6.55s regex_syntax
 5.52s probes
 4.59s llvm_sys
 3.72s regex
 3.45s bpf_sys
 2.71s cc
 2.63s aho_corasick
 2.50s libc
...
```

After:
```
  Time Crate
10.42s redbpf_probes
 9.09s syn
 8.77s bindgen
 6.99s clap
 6.27s clang_sys
 5.63s regex_syntax
 3.74s regex
 3.00s bpf_sys
 2.36s aho_corasick
...
```
