### PR TITLE
Add examples

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,2 +1,2 @@
 [workspace]
-members = ["bpf-sys", "redbpf", "redbpf-probes", "redbpf-macros", "cargo-bpf", "redbpf-tools"]
+members = ["bpf-sys", "redbpf", "redbpf-probes", "redbpf-macros", "cargo-bpf", "redbpf-tools", "examples/example-probes", "examples/example-userspace"]

--- a/examples/example-probes/Cargo.toml
+++ b/examples/example-probes/Cargo.toml
@@ -1,0 +1,24 @@
+[package]
+name = "example-probes"
+version = "0.1.0"
+edition = '2018'
+
+[build-dependencies]
+cargo-bpf = { version = "", path = "../../cargo-bpf", default-features = false, features = ["bindings"] }
+
+[dependencies]
+cty = "0.2"
+redbpf-macros = { version = "", path = "../../redbpf-macros" }
+redbpf-probes = { version = "", path = "../../redbpf-probes" }
+
+[features]
+default = []
+probes = []
+
+[lib]
+path = "src/lib.rs"
+
+[[bin]]
+name = "vfsreadlat"
+path = "src/vfsreadlat/main.rs"
+required-features = ["probes"]

--- a/examples/example-probes/src/lib.rs
+++ b/examples/example-probes/src/lib.rs
@@ -1,0 +1,3 @@
+
+#![no_std]
+pub mod vfsreadlat;

--- a/examples/example-probes/src/vfsreadlat/main.rs
+++ b/examples/example-probes/src/vfsreadlat/main.rs
@@ -1,0 +1,44 @@
+#![no_std]
+#![no_main]
+use example_probes::vfsreadlat::VFSEvent;
+use redbpf_probes::kprobe::prelude::*;
+
+program!(0xFFFFFFFE, "GPL");
+
+#[map("timestamp")]
+static mut timestamp: HashMap<u64, VFSEvent> = HashMap::with_max_entries(10240);
+
+#[map("pid")]
+static mut pid: PerfMap<VFSEvent> = PerfMap::with_max_entries(10240);
+
+#[kprobe("vfs_read")]
+fn vfs_read_enter(_regs: Registers) {
+    let pid_tgid = bpf_get_current_pid_tgid();
+    let p = pid_tgid >> 32;
+    let t = pid_tgid & 0xFFFFFFFF;
+
+    let event = VFSEvent {
+        pid: p,
+        tgid: t,
+        timestamp: bpf_ktime_get_ns(),
+        latency: 0,
+    };
+    unsafe {
+        timestamp.set(&t, &event);
+    };
+}
+
+#[kretprobe("vfs_read")]
+fn vfs_read_exit(regs: Registers) {
+    let t = bpf_get_current_pid_tgid() & 0xFFFFFFFF;
+    unsafe {
+        match timestamp.get_mut(&t) {
+            Some(event) => {
+                timestamp.delete(&t);
+                event.latency = bpf_ktime_get_ns() - event.timestamp;
+                pid.insert(regs.ctx, &event);
+            }
+            None => {}
+        }
+    };
+}

--- a/examples/example-probes/src/vfsreadlat/mod.rs
+++ b/examples/example-probes/src/vfsreadlat/mod.rs
@@ -1,0 +1,20 @@
+
+// use cty::*;
+
+// This is where you should define the types shared by the kernel and user
+// space, eg:
+//
+// #[repr(C)]
+// #[derive(Debug)]
+// pub struct SomeEvent {
+//     pub pid: u64,
+//     ...
+// }
+#[derive(Debug)]
+#[repr(C)]
+pub struct VFSEvent {
+    pub pid: u64,
+    pub tgid: u64,
+    pub timestamp: u64,
+    pub latency: u64,
+}

--- a/examples/example-userspace/Cargo.toml
+++ b/examples/example-userspace/Cargo.toml
@@ -1,0 +1,19 @@
+[package]
+name = "example-userspace"
+version = "0.1.0"
+authors = ["Junyeong Jeong <rhdxmr@gmail.com>"]
+edition = "2018"
+
+[build-dependencies]
+cargo-bpf = { version = "", path = "../../cargo-bpf", default-features = false, features = ["build"] }
+
+[[example]]
+name = "vfsreadlat"
+path = "src/bin/vfsreadlat.rs"
+
+[dependencies]
+probes = { path = "../example-probes", package = "example-probes" }
+libc = ""
+tokio = { version = "", features = ["signal", "time"] }
+redbpf = { version = "", path = "../../redbpf", features = ["load"] }
+futures = ""

--- a/examples/example-userspace/build.rs
+++ b/examples/example-userspace/build.rs
@@ -1,0 +1,20 @@
+use std::env;
+use std::path::{Path, PathBuf};
+
+use cargo_bpf_lib as cargo_bpf;
+
+fn main() {
+    let cargo = PathBuf::from(env::var("CARGO").unwrap());
+    let target = PathBuf::from(env::var("OUT_DIR").unwrap());
+    let probes = Path::new("../example-probes");
+
+    cargo_bpf::build(&cargo, &probes, &target.join("target"), Vec::new())
+        .expect("couldn't compile probes");
+
+    cargo_bpf::probe_files(&probes)
+        .expect("couldn't list probe files")
+        .iter()
+        .for_each(|file| {
+            println!("cargo:rerun-if-changed={}", file);
+        });
+}

--- a/examples/example-userspace/src/bin/vfsreadlat.rs
+++ b/examples/example-userspace/src/bin/vfsreadlat.rs
@@ -1,0 +1,102 @@
+use futures::stream::StreamExt;
+use probes::vfsreadlat::VFSEvent;
+use redbpf::load::{Loaded, Loader};
+use std::collections::HashMap;
+use std::env;
+use std::process;
+use std::ptr;
+use std::sync::{Arc, Mutex};
+use std::time::Duration;
+use tokio;
+use tokio::runtime::Runtime;
+use tokio::signal;
+use tokio::time::delay_for;
+
+const UNDER_ONE: &str = "~ 0";
+const ONE_TO_TEN: &str = "1 ~ 10";
+const TEN_TO_HUNDRED: &str = "10 ~ 100";
+const OVER_HUNDRED: &str = "100 ~";
+
+type Counts = Arc<Mutex<HashMap<&'static str, u64>>>;
+
+fn start_reporter(counts: Counts) {
+    let counts = counts.clone();
+    tokio::spawn(async move {
+        loop {
+            println!("{:>11}\t{}", "latency", "count");
+            for range in &[UNDER_ONE, ONE_TO_TEN, TEN_TO_HUNDRED, OVER_HUNDRED] {
+                let counts = counts.clone();
+                let mut counts = counts.lock().unwrap();
+                let cnt = counts.get_mut(range).unwrap();
+                println!("{:>8} ms\t{}", range, cnt);
+                *cnt = 0;
+            }
+            delay_for(Duration::from_secs(1)).await
+        }
+    });
+}
+
+fn start_perf_event_handler(mut loaded: Loaded, counts: Counts) {
+    let counts = counts.clone();
+    tokio::spawn(async move {
+        while let Some((name, events)) = loaded.events.next().await {
+            for event in events {
+                match name.as_str() {
+                    "pid" => {
+                        let vev = unsafe { ptr::read(event.as_ptr() as *const VFSEvent) };
+                        let latency = vev.latency / 1000_0000;
+                        let range = if latency < 1 {
+                            UNDER_ONE
+                        } else if 1 <= latency && latency < 10 {
+                            ONE_TO_TEN
+                        } else if 10 <= latency && latency < 100 {
+                            TEN_TO_HUNDRED
+                        } else {
+                            OVER_HUNDRED
+                        };
+                        let mut counts = counts.lock().unwrap();
+                        *counts.get_mut(range).unwrap() += 1;
+                    }
+                    _ => panic!("unexpected event"),
+                }
+            }
+        }
+    });
+}
+
+fn main() {
+    if unsafe { libc::getuid() } != 0 {
+        eprintln!("You must be root to use eBPF!");
+        process::exit(1);
+    }
+    let counts: Counts = Arc::new(Mutex::new(
+        [
+            (UNDER_ONE, 0),
+            (ONE_TO_TEN, 0),
+            (TEN_TO_HUNDRED, 0),
+            (OVER_HUNDRED, 0),
+        ]
+        .iter()
+        .cloned()
+        .collect(),
+    ));
+    let _ = Runtime::new().unwrap().block_on(async {
+        let mut loaded = Loader::load(probe_code()).expect("error loading BPF program");
+        for kp in loaded.kprobes_mut() {
+            kp.attach_kprobe(&kp.name(), 0)
+                .expect(&format!("error attaching kprobe program {}", kp.name()));
+        }
+
+        start_perf_event_handler(loaded, counts.clone());
+        start_reporter(counts.clone());
+
+        signal::ctrl_c().await
+    });
+}
+
+fn probe_code() -> &'static [u8] {
+    include_bytes!(concat!(
+        env!("OUT_DIR"),
+        "/target/bpf/programs/vfsreadlat/vfsreadlat.elf"
+    ))
+}


### PR DESCRIPTION
redbpf-examples is added for showing simple BPF programs which are not enough quality to be redbpf-tools. And it is expected that newbies can get to know what they can do with redbpf by studying code of redbpf-examples.


I am a newbie of redbpf and I hope this example code are helpful to other newbies.
And I anticipate that other users of redbpf can put their bpf programs into this example directory easily.