### PR TITLE
Add support for tail calls

### DIFF
--- a/redbpf-probes/src/maps.rs
+++ b/redbpf-probes/src/maps.rs
@@ -12,9 +12,9 @@ Maps are a generic data structure for storage of different types of data.
 They allow sharing of data between eBPF kernel programs, and also between
 kernel and user-space code.
  */
+use core::convert::TryInto;
 use core::default::Default;
 use core::marker::PhantomData;
-use core::convert::TryInto;
 use core::mem;
 use cty::*;
 
@@ -154,7 +154,8 @@ impl PerfMapFlags {
 impl From<PerfMapFlags> for u64 {
     #[inline]
     fn from(flags: PerfMapFlags) -> u64 {
-        (flags.xdp_size as u64) << 32 | (flags.index.unwrap_or(BPF_F_CURRENT_CPU.try_into().unwrap()) as u64)
+        (flags.xdp_size as u64) << 32
+            | (flags.index.unwrap_or(BPF_F_CURRENT_CPU.try_into().unwrap()) as u64)
     }
 }
 

--- a/redbpf/src/lib.rs
+++ b/redbpf/src/lib.rs
@@ -246,6 +246,10 @@ impl Program {
         &self.data().name
     }
 
+    pub fn fd(&self) -> &Option<RawFd> {
+        &self.data().fd
+    }
+
     /// Load the BPF program.
     ///
     /// BPF programs need to be loaded before they can be attached. Loading will fail if the BPF verifier rejects the code.
@@ -576,6 +580,10 @@ impl Module {
             license,
             version,
         })
+    }
+
+    pub fn program(&self, name: &str) -> Option<&Program> {
+        self.programs.iter().find(|p| p.name() == name)
     }
 
     pub fn kprobes(&self) -> impl Iterator<Item = &KProbe> {

--- a/redbpf/src/load/loader.rs
+++ b/redbpf/src/load/loader.rs
@@ -12,7 +12,7 @@ use std::fs;
 use std::io;
 use std::path::Path;
 
-use crate::cpus;
+use crate::{Program, cpus};
 use crate::load::map_io::PerfMessageStream;
 use crate::{Error, KProbe, Map, Module, PerfMap, SocketFilter, UProbe, XDP};
 
@@ -99,6 +99,10 @@ impl Loaded {
 
     pub fn map_mut(&mut self, name: &str) -> Option<&mut Map> {
         self.module.maps.iter_mut().find(|m| m.name == name)
+    }
+
+    pub fn program(&self, name: &str) -> Option<&Program> {
+        self.module.program(name)
     }
 
     pub fn kprobes_mut(&mut self) -> impl Iterator<Item = &mut KProbe> {


### PR DESCRIPTION
This PR adds support for tail calls. 

The user-space API looks like this:

```rust
let mut programs = ProgramArray::new(loader.map("programs").unwrap()).unwrap();
programs
    .set(
        PROGRAM_PARSE_HTTP,
        loader.program("parse_http").unwrap().fd().unwrap(),
    )
```

And the eBPF code looks like this:

```rust
#[map("programs")]
static mut programs: ProgramArray = ProgramArray::with_max_entries(1)

#[uprobe]
fn parse_http(regs: Registers) {
    ...
}

#[uprobe]
fn do_read(regs: Registers) {
    ...
    unsafe { programs.tail_call(regs.ctx, PROGRAM_PARSE_HTTP) };
}
```
