### PR TITLE
Improve cargo_bpf_lib::build::probe_files()

### DIFF
--- a/cargo-bpf/Cargo.toml
+++ b/cargo-bpf/Cargo.toml
@@ -33,6 +33,7 @@ quote = { version = "1.0", optional = true }
 proc-macro2 = {version = "1.0", optional = true}
 tempfile = { version = "3.1", optional = true}
 lazy_static = "1.0"
+glob = "0.3"
 
 [features]
 default = ["command-line"]

--- a/cargo-bpf/src/build.rs
+++ b/cargo-bpf/src/build.rs
@@ -84,14 +84,16 @@ fn build_probe(cargo: &Path, package: &Path, target_dir: &Path, probe: &str) -> 
     flags.push_str(" -C embed-bitcode=yes");
 
     let version = build_kernel_version()
-	.map(|mut v| if v.version >= 5 && v.patchlevel >= 7 {
-	    v.patchlevel = 7;
-	    v
-	} else {
-	    v
-	})
-	.map(|v| format!(r#"kernel_version="{}.{}""#, v.version, v.patchlevel))
-	.unwrap_or(r#"kernel_version="unknown""#.to_string());
+        .map(|mut v| {
+            if v.version >= 5 && v.patchlevel >= 7 {
+                v.patchlevel = 7;
+                v
+            } else {
+                v
+            }
+        })
+        .map(|v| format!(r#"kernel_version="{}.{}""#, v.version, v.patchlevel))
+        .unwrap_or(r#"kernel_version="unknown""#.to_string());
 
     if !Command::new(cargo)
         .current_dir(package)
@@ -102,8 +104,8 @@ fn build_probe(cargo: &Path, package: &Path, target_dir: &Path, probe: &str) -> 
         .arg("--bin")
         .arg(probe)
         .arg("--")
-	.arg("--cfg")
-	.arg(version)
+        .arg("--cfg")
+        .arg(version)
         .args(
             "--emit=llvm-bc -C panic=abort -C lto -C link-arg=-nostartfiles -C opt-level=3"
                 .split(" "),

--- a/cargo-bpf/src/build.rs
+++ b/cargo-bpf/src/build.rs
@@ -6,6 +6,7 @@
 // copied, modified, or distributed except according to those terms.
 
 use bpf_sys::headers::build_kernel_version;
+use glob::{glob, PatternError};
 use std::convert::From;
 use std::env;
 use std::fmt::{self, Display};
@@ -29,6 +30,7 @@ pub enum Error {
     MissingBitcode(String),
     Link(String),
     IOError(io::Error),
+    PatternError(PatternError),
 }
 
 impl std::error::Error for Error {
@@ -59,6 +61,7 @@ impl Display for Error {
             NoOPT => write!(f, "no usable opt executable found, expecting version 9"),
             NoLLC => write!(f, "no usable llc executable found, expecting version 9"),
             IOError(e) => write!(f, "{}", e),
+            PatternError(e) => write!(f, "couldn't list probe files: {}", e),
         }
     }
 }
@@ -214,19 +217,12 @@ pub fn cmd_build(programs: Vec<String>, target_dir: PathBuf) -> Result<(), Comma
 }
 
 pub fn probe_files(package: &Path) -> Result<Vec<String>, Error> {
-    let doc = load_package(package)?;
-    let probes = probe_names(&doc)?;
-    Ok(probes
-        .iter()
-        .map(|probe| {
-            package
-                .join("src")
-                .join(probe)
-                .join("main.rs")
-                .to_string_lossy()
-                .into()
+    glob(&format!("{}/src/**/*.rs", &package.to_string_lossy()))
+        .map_err(|e| Error::PatternError(e))
+        .map(|iter| {
+            iter.filter_map(|entry| entry.ok().map(|path| path.to_string_lossy().into_owned()))
+                .collect()
         })
-        .collect())
 }
 
 fn load_package(package: &Path) -> Result<Document, Error> {


### PR DESCRIPTION
`probe_files()` is called by `build.rs` files to rebuild the user space code whenever the bpf code changes. This PR makes `probe_files()` return all the .rs files under <probe package>/src/, to better deal with complex BPF programs split in several modules.