### PR TITLE
Implement post processing and code generation with libLLVM

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,10 +52,8 @@ project](https://github.com/redsift/ingraind/tree/v1.0.0).
 In order to build some of the code here, you will need the following:
 
  * Linux 4.19+, with a build tree. The build tree is picked up from standard locations, or the `KERNEL_SOURCE` environment variable.
- * LLVM 10
+ * LLVM 11. For debian based distros that don't have LLVM 11, you can find packages at https://apt.llvm.org. For rpm based ones, you can get it from Fedora Rawhide.
  * The latest stable Rust compiler. We only promise to build with the latest stable and nightly compilers.
-
-NOTE: the latest `nightly` compilers will use LLVM 11, which doesn't ship with most distributions. Use a stable compiler for the time being.
 
 # Getting started
 

--- a/cargo-bpf/Cargo.toml
+++ b/cargo-bpf/Cargo.toml
@@ -34,6 +34,7 @@ proc-macro2 = {version = "1.0", optional = true}
 tempfile = { version = "3.1", optional = true}
 lazy_static = "1.0"
 glob = "0.3"
+anyhow = "1.0"
 
 [features]
 default = ["command-line"]

--- a/cargo-bpf/src/llvm.rs
+++ b/cargo-bpf/src/llvm.rs
@@ -9,6 +9,7 @@ use llvm_sys::target_machine::*;
 use llvm_sys::transforms::ipo::LLVMAddAlwaysInlinerPass;
 use llvm_sys::transforms::pass_manager_builder::*;
 use llvm_sys::{LLVMAttributeFunctionIndex, LLVMInlineAsmDialect::*};
+use llvm_sys::support::LLVMParseCommandLineOptions;
 use std::ffi::{CStr, CString};
 use std::os::raw::c_char;
 use std::path::Path;
@@ -20,6 +21,13 @@ pub unsafe fn init() {
     LLVM_InitializeAllTargetMCs();
     LLVM_InitializeAllAsmPrinters();
     LLVM_InitializeAllAsmParsers();
+
+    let mut args = Vec::new();
+    args.push(CString::new("cargo-bpf").unwrap());
+    args.push(CString::new(format!("-unroll-threshold={}", std::u32::MAX)).unwrap());
+    let args_ptrs = args.iter().map(|s| s.as_ptr()).collect::<Vec<_>>();
+    let overview = CString::new("what is this").unwrap();
+    LLVMParseCommandLineOptions(args.len() as i32, args_ptrs.as_ptr(), overview.as_ptr());
 }
 
 unsafe fn load_module(context: LLVMContextRef, input: &Path) -> Result<LLVMModuleRef> {


### PR DESCRIPTION
This PR makes cargo-bpf use libLLVM directly to generate code instead of using opt + llc. This is more robust and gives us the possibility to implement more custom optimizations in the future. Also, now upgrading LLVM version is matter of updating the `llvm-sys` version in Cargo.toml.

Note that by using libLLVM we use the legacy pass manager (the only one available), instead of the new pass manager used by opt and llc, so the compilation pipeline isn't 100% the same. I have tested with ingraind, redbpf-tools and snuffy and everything seems to work ok.

The PR is based on https://github.com/redsift/redbpf/pull/95 so that should be merged first.

@rsdy it would be great if you could run this on the ingraind CI and see how things look in the terraform jobs.
