### PR TITLE
Add support for `tc` actions

### DIFF
--- a/redbpf-probes/src/lib.rs
+++ b/redbpf-probes/src/lib.rs
@@ -56,6 +56,8 @@ pub mod kprobe;
 pub mod maps;
 pub mod net;
 pub mod registers;
+pub mod socket;
 pub mod socket_filter;
+pub mod tc;
 pub mod uprobe;
 pub mod xdp;

--- a/redbpf-probes/src/socket.rs
+++ b/redbpf-probes/src/socket.rs
@@ -1,0 +1,76 @@
+//! Socket related type and functions
+
+use crate::bindings::*;
+use crate::helpers::bpf_skb_load_bytes;
+use core::mem::{size_of, MaybeUninit};
+
+pub trait FromBe {
+    fn from_be(&self) -> Self;
+}
+
+macro_rules! impl_from_be {
+    ($T:ident) => {
+        impl FromBe for $T {
+            fn from_be(&self) -> $T {
+                $T::from_be(*self)
+            }
+        }
+    };
+}
+
+impl_from_be!(u8);
+impl_from_be!(u16);
+impl_from_be!(u32);
+
+// Errors in socket-related programs
+pub enum SocketError {
+    /// Loading data from the socket buffer failed.
+    LoadFailed,
+}
+
+/// Context object provided to Socket-related programs.
+pub struct SkBuff {
+    /// The low level skb instance.
+    pub skb: *const __sk_buff,
+}
+
+impl SkBuff {
+    #[inline]
+    /// Loads data from the socket buffer.
+    ///
+    /// # Example
+    /// ```no_run
+    /// use core::mem;
+    /// use memoffset::offset_of;
+    /// use redbpf_probes::socket_filter::prelude::*;
+    ///
+    /// #[socket_filter]
+    /// fn forward_tcp(skb: SkBuff) -> SkBuffResult {
+    ///     let eth_len = mem::size_of::<ethhdr>();
+    ///     let eth_proto: u16 = skb.load(offset_of!(ethhdr, h_proto))?;
+    ///     let ip_proto: u8 = skb.load(eth_len + offset_of!(iphdr, protocol))?;
+    ///
+    ///     // only parse TCP
+    ///     if !(eth_proto as u32 == ETH_P_IP && ip_proto as u32 == IPPROTO_TCP) {
+    ///         return Ok(SkBuffAction::Ignore);
+    ///     }
+    ///     Ok(SkBuffAction::SendToUserspace)
+    /// }
+    /// ```
+    pub fn load<T: FromBe>(&self, offset: usize) -> Result<T, SocketError> {
+        unsafe {
+            let mut data = MaybeUninit::<T>::uninit();
+            let ret = bpf_skb_load_bytes(
+                self.skb as *const _,
+                offset as u32,
+                &mut data as *mut _ as *mut _,
+                size_of::<T>() as u32,
+            );
+            if ret < 0 {
+                return Err(SocketError::LoadFailed);
+            }
+
+            Ok(data.assume_init().from_be())
+        }
+    }
+}

--- a/redbpf-probes/src/socket_filter/mod.rs
+++ b/redbpf-probes/src/socket_filter/mod.rs
@@ -38,27 +38,7 @@ fn forward_tcp(skb: SkBuff) -> SkBuffResult {
 */
 pub mod prelude;
 
-use crate::bindings::*;
-use crate::helpers::bpf_skb_load_bytes;
-use core::mem;
-
-pub trait FromBe {
-    fn from_be(&self) -> Self;
-}
-
-macro_rules! impl_from_be {
-    ($T:ident) => {
-        impl FromBe for $T {
-            fn from_be(&self) -> $T {
-                $T::from_be(*self)
-            }
-        }
-    };
-}
-
-impl_from_be!(u8);
-impl_from_be!(u16);
-impl_from_be!(u32);
+use crate::socket::SocketError;
 
 /// The return type for successful socket filter programs.
 pub enum SkBuffAction {
@@ -71,63 +51,5 @@ pub enum SkBuffAction {
     SendToUserspace,
 }
 
-/// The error type for socket filter programs.
-pub enum SkBuffError {
-    /// Loading data from the socket buffer failed.
-    LoadFailed,
-}
-
 /// Result type for socket filter programs.
-pub type SkBuffResult = Result<SkBuffAction, SkBuffError>;
-
-/// Context object provided to Socket Filter programs.
-///
-/// Socket Filter programs are passed a `SkBuff` instance as their argument.
-pub struct SkBuff {
-    /// The low level skb instance.
-    pub skb: *const __sk_buff,
-}
-
-impl SkBuff {
-    #[inline]
-    /// Loads data from the socket buffer.
-    ///
-    /// This is typically used to parse payloads before deciding whether to
-    /// forward them to userspace or not.
-    ///
-    /// # Example
-    /// ```no_run
-    /// use core::mem;
-    /// use memoffset::offset_of;
-    /// use redbpf_probes::socket_filter::prelude::*;
-    ///
-    /// #[socket_filter]
-    /// fn forward_tcp(skb: SkBuff) -> SkBuffResult {
-    ///     let eth_len = mem::size_of::<ethhdr>();
-    ///     let eth_proto: u16 = skb.load(offset_of!(ethhdr, h_proto))?;
-    ///     let ip_proto: u8 = skb.load(eth_len + offset_of!(iphdr, protocol))?;
-    ///
-    ///     // only parse TCP
-    ///     if !(eth_proto as u32 == ETH_P_IP && ip_proto as u32 == IPPROTO_TCP) {
-    ///         return Ok(SkBuffAction::Ignore);
-    ///     }
-    ///     Ok(SkBuffAction::SendToUserspace)
-    /// }
-    /// ```
-    pub fn load<T: FromBe>(&self, offset: usize) -> Result<T, SkBuffError> {
-        unsafe {
-            let mut data = mem::MaybeUninit::<T>::uninit();
-            let ret = bpf_skb_load_bytes(
-                self.skb as *const _,
-                offset as u32,
-                &mut data as *mut _ as *mut _,
-                mem::size_of::<T>() as u32,
-            );
-            if ret < 0 {
-                return Err(SkBuffError::LoadFailed);
-            }
-
-            Ok(data.assume_init().from_be())
-        }
-    }
-}
+pub type SkBuffResult = Result<SkBuffAction, SocketError>;

--- a/redbpf-probes/src/socket_filter/prelude.rs
+++ b/redbpf-probes/src/socket_filter/prelude.rs
@@ -12,9 +12,10 @@
 //! ```
 //! use redbpf_probes::socket_filter::prelude::*;
 //! ```
-pub use cty::*;
-pub use redbpf_macros::{program, socket_filter};
 pub use crate::bindings::*;
 pub use crate::helpers::*;
 pub use crate::maps::*;
+pub use crate::socket::*;
 pub use crate::socket_filter::*;
+pub use cty::*;
+pub use redbpf_macros::{program, socket_filter};

--- a/redbpf-probes/src/tc/mod.rs
+++ b/redbpf-probes/src/tc/mod.rs
@@ -1,0 +1,29 @@
+use crate::socket::SocketError;
+
+/// Possible actions in tc programs
+pub enum TcAction {
+    /// Terminate the packet processing pipeline and allows the packet to proceed
+    Ok,
+    /// Terminate the packet processing pipeline and drops the packet
+    Shot,
+    /// Use the default action configured from `tc`
+    Unspec,
+    /// Iterate to the next action, if available
+    Pipe,
+    /// Terminate the packet processing pipeline and
+    /// start classification from the beginning
+    Reclassify,
+}
+
+/// Result type for tc action programs.
+pub type TcActionResult = Result<TcAction, SocketError>;
+
+pub mod prelude {
+    pub use super::*;
+
+    pub use crate::bindings::*;
+    pub use crate::helpers::*;
+    pub use crate::maps::*;
+    pub use crate::socket::*;
+    pub use redbpf_macros::{program, tc_action};
+}


### PR DESCRIPTION
This work has been on my fork a couple month now, and I had a conversation with @alessandrod about this when he said he would like to add support for `tc` programs, that is also almost a month ago now... Forgive my laziness but anyway here I am ready to kick off this effort.

You can see in this PR that I've moved the `SkBuff` out of the `socket_filter` module, since `tc` programs use it for input as well, and (I believe) I followed existing example for other shared data structures for probes. I also plan to add a few more utility functions in `SkBuff` for example to test for specific protocol, and jump to packet data start - since IP and TCP header has some peculiar header length calculation that I spent quite a while to figure out. 

I picked the macro name `tc_action` because as I understand, there're also "classifiers" for `tc`, although I haven't really figure it out what they do or whether they're really different than "action" programs. As far as I remember, they have different return codes, so I believe it makes sense to separate them based on that.

Note with only this PR, the output ELF still cannot be loaded by `tc`. At least two problems that I've found workarounds:

- Strip `.text` section
- Rename `maps` section

As a complete working example, you can see [this project](https://github.com/aquarhead/protect-the-rabbit), and the workarounds are codified [here](https://github.com/aquarhead/protect-the-rabbit/blob/master/Makefile.toml#L10-L18).

I think it's possible that we integrate these extra LLVM tools, but I'd like to see your opinion first. Also I'd really like to understand what's in the `.text` section anyway...

Another potential issue is how to use multiple maps if `tc` only expects a single section, though it might not be an issue but I don't think I've tried it.

On a sidenote, I submitted a lightning talk on exactly this work for the eBPF summit, and it got accepted, I'd really appreciate it if you would like to see my draft (I need to prepare a recorded video before Friday).