### PR TITLE
examples: Fix dependency version conflict

### DIFF
--- a/examples/example-userspace/Cargo.toml
+++ b/examples/example-userspace/Cargo.toml
@@ -13,7 +13,7 @@ path = "src/bin/vfsreadlat.rs"
 
 [dependencies]
 probes = { path = "../example-probes", package = "example-probes" }
-libc = ""
-tokio = { version = "", features = ["signal", "time"] }
+libc = "0.2"
+tokio = { version = "^0.2.4", features = ["signal", "time"] }
 redbpf = { version = "", path = "../../redbpf", features = ["load"] }
-futures = ""
+futures = "0.3"


### PR DESCRIPTION
This PR intended to resolve the dependency version conflict.
tokio already used by redbpf-tools that is version 0.2.4, meanwhile example-userspace may uses the differ version, it leads to the version conflict.

If you review this PR, I would be appreciated.

Regards,
