### PR TITLE
allows specifying the link_section for a map

### DIFF
--- a/redbpf-macros/Cargo.toml
+++ b/redbpf-macros/Cargo.toml
@@ -17,6 +17,9 @@ proc-macro2 = "1.0"
 syn = {version = "1.0", features = ["full"] }
 quote = "1.0"
 
+[build-dependencies]
+rustc_version = "0.3.0"
+
 [dev-dependencies]
 # redbpf-probes is needed by doctests
 redbpf-probes = { version = "^1.2.0", path = "../redbpf-probes" }

--- a/redbpf-macros/build.rs
+++ b/redbpf-macros/build.rs
@@ -1,0 +1,20 @@
+extern crate rustc_version;
+use rustc_version::{version_meta, Channel};
+
+fn main() {
+    // Set cfg flags depending on release channel
+    match version_meta().unwrap().channel {
+        Channel::Stable => {
+            println!("cargo:rustc-cfg=RUSTC_IS_STABLE");
+        }
+        Channel::Beta => {
+            println!("cargo:rustc-cfg=RUSTC_IS_BETA");
+        }
+        Channel::Nightly => {
+            println!("cargo:rustc-cfg=RUSTC_IS_NIGHTLY");
+        }
+        Channel::Dev => {
+            println!("cargo:rustc-cfg=RUSTC_IS_DEV");
+        }
+    }
+}

--- a/redbpf-macros/src/lib.rs
+++ b/redbpf-macros/src/lib.rs
@@ -49,7 +49,10 @@ use std::str;
 use syn::parse::{Parse, ParseStream};
 use syn::punctuated::Punctuated;
 use syn::token::Comma;
-use syn::{parse_macro_input, parse_quote, parse_str, Expr, ExprLit, File, ItemFn, Lit, Result};
+use syn::{
+    parse_macro_input, parse_quote, parse_str, Expr, ExprLit, File, ItemFn, ItemStatic, Lit, Meta,
+    Result,
+};
 
 fn inline_string_literal(e: &Expr) -> (TokenStream2, TokenStream2) {
     let bytes = match e {
@@ -150,10 +153,23 @@ pub fn impl_network_buffer_array(_: TokenStream) -> TokenStream {
 /// Attribute macro that must be used when creating [eBPF
 /// maps](https://ingraind.org/api/redbpf_probes/maps/index.html).
 ///
+/// The default `#[map]` places the map into a section of the resulting
+/// ELF binary called `maps/<item_name>`.
+///
+/// If you wish to set the section name manually for BPF programs that
+/// require strict naming conventions use `#[map(link_section = "foo")]`
+/// which place the map into a section called `foo`.
+///
 /// # Example
+///
 /// ```no_run
 /// # use redbpf_probes::kprobe::prelude::*;
-/// #[map("dns_queries")]
+/// // Will be linked into the ELF in the section 'maps/counts'
+/// #[map]
+/// static mut counts: PerfMap<u64> = PerfMap::with_max_entries(10240);
+///
+/// // Will be linked into the ELF in the section 'dns_queries'
+/// #[map(link_section = "dns_queries")]
 /// static mut queries: PerfMap<Query> = PerfMap::with_max_entries(1024);
 ///
 /// struct Query {
@@ -162,15 +178,26 @@ pub fn impl_network_buffer_array(_: TokenStream) -> TokenStream {
 /// ```
 #[proc_macro_attribute]
 pub fn map(attrs: TokenStream, item: TokenStream) -> TokenStream {
-    let attrs = parse_macro_input!(attrs as Expr);
-    let name = match attrs {
-        Expr::Lit(ExprLit {
-            lit: Lit::Str(s), ..
-        }) => s.value().clone(),
-        _ => panic!("expected string literal"),
+    let section_name = if attrs.is_empty() {
+        let item = item.clone();
+        let item = parse_macro_input!(item as ItemStatic);
+        format!("maps/{}", item.ident.to_string())
+    } else {
+        let meta = parse_macro_input!(attrs as Meta);
+        match meta {
+            Meta::NameValue(mnv) => {
+                if !mnv.path.is_ident("link_section") {
+                    panic!("expected #[map(link_section = \"...\")]");
+                }
+                match mnv.lit {
+                    Lit::Str(lit_str) => lit_str.value(),
+                    _ => panic!("expected #[map(link_section = \"...\")]"),
+                }
+            }
+            _ => panic!("expected #[map(link_section = \"...\")]"),
+        }
     };
 
-    let section_name = format!("maps/{}", name);
     let item = TokenStream2::from(item);
     let tokens = quote! {
         #[no_mangle]


### PR DESCRIPTION
This commit changes the `map` attribute macro to allow specifying a section
name manually, or using the item name when explict names are omitted.

For example, the *old* version:

```rust
static mut counts: PerfMap<u64> = PerfMap::with_max_entries(10240);
```

Would place the map in the `maps/counts` section of the resulting ELF
binary. Note the repetition of the names.

The new style infers the name from the item:

```rust
static mut counts: PerfMap<u64> = PerfMap::with_max_entries(10240);
```

Which still places the map in the `maps/counts` section of the binary.

However, in some cases the default naming scheme does not work (such as
in `tc` BPF programs). If the link section must be supplied manually,
one can use this method:

```rust
static mut counts: PerfMap<u64> = PerfMap::with_max_entries(10240);
```

In this case the map will be placed in the explicit `foo` section of the
binary.

Closes #105