### PR TITLE
Reduces bindgen child-deps + fixes clippy lints

### DIFF
--- a/bpf-sys/Cargo.toml
+++ b/bpf-sys/Cargo.toml
@@ -16,5 +16,5 @@ libc = "0.2"
 
 [build-dependencies]
 cc = "1.0"
-bindgen = "0.55"
+bindgen = {version = "0.55", default-features = false, features = ["runtime"]}
 libc = "0.2"

--- a/bpf-sys/build.rs
+++ b/bpf-sys/build.rs
@@ -9,7 +9,7 @@
 use std::env;
 use std::path::PathBuf;
 
-const KERNEL_HEADERS: [&'static str; 6] = [
+const KERNEL_HEADERS: [&str; 6] = [
     "arch/x86/include/generated/uapi",
     "arch/x86/include/uapi",
     "arch/x86/include/",

--- a/bpf-sys/src/uname.rs
+++ b/bpf-sys/src/uname.rs
@@ -12,6 +12,7 @@ use std::str::from_utf8_unchecked;
 use std::str::FromStr;
 use std::fs;
 
+#[allow(clippy::result_unit_err)]
 pub fn uname() -> Result<::libc::utsname, ()> {
     let mut uname = unsafe { mem::zeroed() };
     let res = unsafe { ::libc::uname(&mut uname) };
@@ -35,13 +36,14 @@ pub fn get_kernel_internal_version() -> Option<u32> {
     })
 }
 
+#[allow(clippy::result_unit_err)]
 #[inline]
 pub fn get_fqdn() -> Result<String, ()> {
     let uname = uname()?;
     let mut hostname = to_str(&uname.nodename).to_string();
     let domainname = to_str(&uname.domainname);
     if domainname != "(none)" {
-        hostname.push_str(".");
+        hostname.push('.');
         hostname.push_str(domainname);
     }
 
@@ -54,18 +56,18 @@ pub fn to_str(bytes: &[c_char]) -> &str {
 }
 
 fn parse_version_signature(signature: &str) -> Option<String> {
-    let parts: Vec<_> = signature.split(" ").collect();
+    let parts: Vec<_> = signature.split(' ').collect();
     if parts.len() != 3 {
         return None;
     }
 
-    parts.last().map(|v| v.clone().into())
+    parts.last().map(|v| <&str>::clone(v).into())
 }
 
 fn parse_version(version: &str) -> Option<(u32, u32, u32)> {
-    if let Some(version) = version.splitn(2, "-").next() {
-        if let Some(version) = version.splitn(2, "+").next() {
-            let parts: Vec<_> = version.splitn(3, ".").filter_map(|v| u32::from_str(v).ok()).collect();
+    if let Some(version) = version.splitn(2, '-').next() {
+        if let Some(version) = version.splitn(2, '+').next() {
+            let parts: Vec<_> = version.splitn(3, '.').filter_map(|v| u32::from_str(v).ok()).collect();
             if parts.len() != 3 {
                 return None;
             }

--- a/cargo-bpf/Cargo.toml
+++ b/cargo-bpf/Cargo.toml
@@ -19,7 +19,7 @@ required-features = ["command-line"]
 
 [dependencies]
 clap = { version = "2.33", optional = true }
-bindgen = { version = "0.55", optional = true }
+bindgen = {version = "0.55", default-features = false, features = ["runtime"], optional = true}
 toml_edit = { version = "0.2", optional = true }
 bpf-sys = { version = "^1.2.0", path = "../bpf-sys", optional = true }
 redbpf = { version = "^1.2.0", path = "../redbpf", default-features = false, optional = true }

--- a/cargo-bpf/src/bindgen.rs
+++ b/cargo-bpf/src/bindgen.rs
@@ -11,7 +11,6 @@ use std::io::{self, Write};
 use std::path::Path;
 use std::process::Command;
 use std::str;
-use tempfile;
 
 pub use crate::accessors::generate_read_accessors;
 use crate::build_constants::{kernel_headers, BUILD_FLAGS};
@@ -76,7 +75,7 @@ pub fn cmd_bindgen(header: &Path, extra_args: &[&str]) -> Result<(), CommandErro
     };
 
     let builder = builder().header(header.to_str().unwrap());
-    let bindings = generate(&builder, extra_args).map_err(|e| CommandError(e))?;
+    let bindings = generate(&builder, extra_args).map_err(CommandError)?;
     let mut out = io::stdout();
     writeln!(
         &mut out,

--- a/cargo-bpf/src/llvm.rs
+++ b/cargo-bpf/src/llvm.rs
@@ -81,12 +81,13 @@ unsafe fn inject_exit_call(context: LLVMContextRef, func: LLVMValueRef, builder:
     let block = LLVMGetLastBasicBlock(func);
     let last = LLVMGetLastInstruction(block);
     LLVMPositionBuilderBefore(builder, last);
+    let c_str = CString::new("").unwrap();
     LLVMBuildCall(
         builder,
         exit,
         ptr::null_mut(),
         0,
-        CString::new("").unwrap().as_ptr(),
+        c_str.as_ptr(),
     );
 }
 
@@ -111,7 +112,7 @@ pub unsafe fn process_ir(context: LLVMContextRef, module: LLVMModuleRef) -> Resu
     let always_inline_attr = LLVMCreateEnumAttribute(context, always_inline_kind, 0);
 
     let mut func = LLVMGetFirstFunction(module);
-    while func != ptr::null_mut() {
+    while !func.is_null() {
         let mut size: libc::size_t = 0;
         let name = CStr::from_ptr(LLVMGetValueName2(func, &mut size as *mut _))
             .to_str()
@@ -209,7 +210,7 @@ unsafe fn compile_module(
     // run function passes
     LLVMInitializeFunctionPassManager(fpm);
     let mut func = LLVMGetFirstFunction(module);
-    while func != ptr::null_mut() {
+    while !func.is_null() {
         if LLVMIsDeclaration(func) == 0 {
             LLVMRunFunctionPassManager(fpm, func);
         }

--- a/cargo-bpf/src/load.rs
+++ b/cargo-bpf/src/load.rs
@@ -12,7 +12,6 @@ use hexdump::hexdump;
 use redbpf::xdp;
 use redbpf::{load::Loader, Program::*};
 use std::path::PathBuf;
-use tokio;
 use tokio::runtime::Runtime;
 use tokio::signal;
 

--- a/cargo-bpf/src/main.rs
+++ b/cargo-bpf/src/main.rs
@@ -235,10 +235,10 @@ fn main() {
         let target_dir = m
             .value_of("TARGET_DIR")
             .map(PathBuf::from)
-            .unwrap_or(current_dir.join("target"));
+            .unwrap_or_else(||current_dir.join("target"));
         let programs = m
             .values_of("NAME")
-            .map(|i| i.map(|s| String::from(s)).collect())
+            .map(|i| i.map(String::from).collect())
             .unwrap_or_else(Vec::new);
         if let Err(e) = cargo_bpf::cmd_build(programs, target_dir) {
             clap::Error::with_description(&e.0, clap::ErrorKind::InvalidValue).exit()

--- a/redbpf-macros/src/lib.rs
+++ b/redbpf-macros/src/lib.rs
@@ -63,7 +63,7 @@ fn inline_string_literal(e: &Expr) -> (TokenStream2, TokenStream2) {
     let bytes = match e {
         Expr::Lit(ExprLit {
             lit: Lit::Str(s), ..
-        }) => s.value().clone().into_bytes(),
+        }) => s.value().into_bytes(),
         _ => panic!("expected string literal"),
     };
 
@@ -232,7 +232,7 @@ fn probe_impl(ty: &str, attrs: TokenStream, item: ItemFn, mut name: String) -> T
         name = match parse_macro_input!(attrs as Expr) {
             Expr::Lit(ExprLit {
                 lit: Lit::Str(s), ..
-            }) => s.value().clone(),
+            }) => s.value(),
             _ => panic!("expected string literal"),
         }
     };
@@ -277,7 +277,7 @@ pub fn kprobe(attrs: TokenStream, item: TokenStream) -> TokenStream {
     let item = parse_macro_input!(item as ItemFn);
     let name = item.sig.ident.to_string();
     let wrapper = wrap_kprobe(item);
-    probe_impl("kprobe", attrs, wrapper, name).into()
+    probe_impl("kprobe", attrs, wrapper, name)
 }
 
 /// Attribute macro that must be used to define [`kretprobes`](https://www.kernel.org/doc/Documentation/kprobes.txt).
@@ -296,7 +296,7 @@ pub fn kretprobe(attrs: TokenStream, item: TokenStream) -> TokenStream {
     let item = parse_macro_input!(item as ItemFn);
     let name = item.sig.ident.to_string();
     let wrapper = wrap_kprobe(item);
-    probe_impl("kretprobe", attrs, wrapper, name).into()
+    probe_impl("kretprobe", attrs, wrapper, name)
 }
 
 /// Attribute macro that must be used to define [`uprobes`](https://www.kernel.org/doc/Documentation/trace/uprobetracer.txt).
@@ -315,7 +315,7 @@ pub fn uprobe(attrs: TokenStream, item: TokenStream) -> TokenStream {
     let item = parse_macro_input!(item as ItemFn);
     let name = item.sig.ident.to_string();
     let wrapper = wrap_kprobe(item);
-    probe_impl("uprobe", attrs, wrapper, name).into()
+    probe_impl("uprobe", attrs, wrapper, name)
 }
 
 /// Attribute macro that must be used to define [`uretprobes`](https://www.kernel.org/doc/Documentation/trace/uprobetracer.txt).
@@ -334,7 +334,7 @@ pub fn uretprobe(attrs: TokenStream, item: TokenStream) -> TokenStream {
     let item = parse_macro_input!(item as ItemFn);
     let name = item.sig.ident.to_string();
     let wrapper = wrap_kprobe(item);
-    probe_impl("uretprobe", attrs, wrapper, name).into()
+    probe_impl("uretprobe", attrs, wrapper, name)
 }
 
 /// Attribute macro that must be used to define [`XDP` probes](https://www.iovisor.org/technology/xdp).
@@ -370,7 +370,7 @@ pub fn xdp(attrs: TokenStream, item: TokenStream) -> TokenStream {
             #item
         }
     };
-    probe_impl("xdp", attrs, wrapper, name).into()
+    probe_impl("xdp", attrs, wrapper, name)
 }
 
 /// Attribute macro that must be used to define [`socket
@@ -407,7 +407,7 @@ pub fn socket_filter(attrs: TokenStream, item: TokenStream) -> TokenStream {
         }
     };
 
-    probe_impl("socketfilter", attrs, wrapper, name).into()
+    probe_impl("socketfilter", attrs, wrapper, name)
 }
 
 /// Define [tc action BPF programs](https://man7.org/linux/man-pages/man8/tc-bpf.8.html)
@@ -433,5 +433,5 @@ pub fn tc_action(attrs: TokenStream, item: TokenStream) -> TokenStream {
         }
     };
 
-    probe_impl("tc_action", attrs, wrapper, name).into()
+    probe_impl("tc_action", attrs, wrapper, name)
 }

--- a/redbpf-probes/build.rs
+++ b/redbpf-probes/build.rs
@@ -152,11 +152,11 @@ impl Visit<'_> for RewriteBpfHelpers {
 }
 
 fn gen_helpers(helpers: &str) -> String {
-    let mut tree: syn::File = parse_str(&helpers).unwrap();
+    let tree: syn::File = parse_str(&helpers).unwrap();
     let mut tx = RewriteBpfHelpers {
         helpers: Vec::new(),
     };
-    tx.visit_file(&mut tree);
+    tx.visit_file(&tree);
     let mut out = String::new();
     out.push_str("use crate::bindings::*;\n");
     for helper in &tx.helpers {

--- a/redbpf-probes/src/maps.rs
+++ b/redbpf-probes/src/maps.rs
@@ -155,7 +155,7 @@ impl From<PerfMapFlags> for u64 {
     #[inline]
     fn from(flags: PerfMapFlags) -> u64 {
         (flags.xdp_size as u64) << 32
-            | (flags.index.unwrap_or(BPF_F_CURRENT_CPU.try_into().unwrap()) as u64)
+            | (flags.index.unwrap_or_else(|| BPF_F_CURRENT_CPU.try_into().unwrap()) as u64)
     }
 }
 

--- a/redbpf-probes/src/net.rs
+++ b/redbpf-probes/src/net.rs
@@ -71,13 +71,32 @@ where
         self.data_end() - self.data_start()
     }
 
+    /// Returns a raw pointer to a given address inside the buffer.
+    ///
+    /// # Safety
+    ///
+    /// This method uses `NetworkBuffer::check_bounds` to ensure the given address
+    /// `addr` is within the buffer and allows enough following space to point
+    /// to something of type `U`. However no checks are done to ensure the
+    /// returned pointer points to a valid bit pattern of type `U`, nor are any
+    /// alignments checked. Ensuring proper alignment is followed and pointed to
+    /// address is a valid bit pattern of type `U` is left up to the caller.
     #[inline]
     unsafe fn ptr_at<U>(&self, addr: usize) -> NetworkResult<*const U> {
         self.check_bounds(addr, addr + mem::size_of::<U>())?;
 
         Ok(addr as *const U)
     }
-
+    /// Returns a raw pointer to the address following `prev` plus the size of a `T`
+    ///
+    /// # Safety
+    ///
+    /// This method uses `NetworkBuffer::check_bounds` to ensure the given address
+    /// `addr` is within the buffer and allows enough following space to point
+    /// to something of type `U`. However no checks are done to ensure the
+    /// returned pointer points to a valid bit pattern of type `U`, nor are any
+    /// alignments checked. Ensuring proper alignment is followed and pointed to
+    /// address is a valid bit pattern of type `U` is left up to the caller.
     #[inline]
     unsafe fn ptr_after<T, U>(&self, prev: *const T) -> NetworkResult<*const U> {
         self.ptr_at(prev as usize + mem::size_of::<T>())
@@ -97,7 +116,7 @@ where
             return Err(NetworkError::OutOfBounds);
         }
 
-        return Ok(());
+        Ok(())
     }
 
     /// Returns the packet's `Ethernet` header if present.

--- a/redbpf/Cargo.toml
+++ b/redbpf/Cargo.toml
@@ -19,7 +19,7 @@ bpf-sys = { path = "../bpf-sys", version = "^1.2.0" }
 goblin = "0.2"
 zero = "0.1"
 libc = "0.2"
-bindgen = "0.55"
+bindgen = {version = "0.55", default-features = false, features = ["runtime"]}
 regex = "1.0"
 lazy_static = "1.0"
 byteorder = "1"

--- a/redbpf/src/load/loader.rs
+++ b/redbpf/src/load/loader.rs
@@ -32,7 +32,7 @@ impl Loader {
     /// This will parse `data` with `Module::parse()` and load all the programs
     /// present in the module.
     pub fn load(data: &[u8]) -> Result<Loaded, LoaderError> {
-        let mut module = Module::parse(&data).map_err(|e| LoaderError::ParseError(e))?;
+        let mut module = Module::parse(&data).map_err(LoaderError::ParseError)?;
         for program in module.programs.iter_mut() {
             program
                 .load(module.version, module.license.clone())
@@ -65,7 +65,7 @@ impl Loader {
     ///
     /// See `load()`.
     pub fn load_file<P: AsRef<Path>>(file: P) -> Result<Loaded, LoaderError> {
-        Loader::load(&fs::read(file).map_err(|e| LoaderError::FileError(e))?)
+        Loader::load(&fs::read(file).map_err(LoaderError::FileError)?)
     }
 }
 

--- a/redbpf/src/symbols.rs
+++ b/redbpf/src/symbols.rs
@@ -21,7 +21,7 @@ lazy_static! {
         LdSoCache::load("/etc/ld.so.cache");
 }
 
-const CACHE_HEADER: &'static str = "glibc-ld.so.cache1.1";
+const CACHE_HEADER: &str = "glibc-ld.so.cache1.1";
 
 pub(crate) struct ElfSymbols<'a> {
     elf: Elf<'a>,
@@ -87,7 +87,7 @@ pub(crate) struct LdSoCache {
 
 impl LdSoCache {
     pub fn load(path: &str) -> Result<Self, CacheError> {
-        let data = fs::read(path).map_err(|e| CacheError::IOError(e))?;
+        let data = fs::read(path).map_err(CacheError::IOError)?;
         Self::parse(&data)
     }
 
@@ -95,7 +95,7 @@ impl LdSoCache {
         let mut cursor = Cursor::new(data);
 
         let mut buf = [0u8; CACHE_HEADER.len()];
-        cursor.read(&mut buf)?;
+        cursor.read_exact(&mut buf)?;
         let header = str::from_utf8(&buf).or(Err(CacheError::InvalidHeader))?;
         if header != CACHE_HEADER {
             return Err(CacheError::InvalidHeader);
@@ -150,7 +150,7 @@ fn proc_maps_libs(pid: pid_t) -> io::Result<Vec<(String, String)>> {
         .lines()
         .filter_map(|line| {
             let line = line.split_whitespace().last()?;
-            if line.starts_with("/") {
+            if line.starts_with('/') {
                 let path = PathBuf::from(line);
                 let key = path.file_name().unwrap().to_string_lossy().into_owned();
                 let value = path.to_string_lossy().into_owned();

--- a/redbpf/src/xdp.rs
+++ b/redbpf/src/xdp.rs
@@ -34,6 +34,9 @@ pub struct MapData<T> {
 }
 
 impl<T> MapData<T> {
+    /// # Safety
+    ///
+    /// Casts a pointer of `Sample.data` to `*const MapData<U>`
     pub unsafe fn from_sample<U>(sample: &Sample) -> &MapData<U> {
         &*(sample.data.as_ptr() as *const MapData<U>)
     }


### PR DESCRIPTION
This PR is in two commits:

- Reducing compile time deps of `bindgen` by removing default features (these deps are not required by anything `redbpf` is doing)
- Fixes a bunch of clippy lints.

The commits have decent messages to explain the details.

Tests are currently failing on `master` so I wasn't able to check that, but all tests that pass on master still pass here. I also compiled against current stable and current nightly.