### PR TITLE
Skips re-run of build.rs if C source doesnt change

### DIFF
--- a/bpf-sys/Cargo.toml
+++ b/bpf-sys/Cargo.toml
@@ -18,3 +18,4 @@ libc = "0.2"
 cc = "1.0"
 bindgen = {version = "0.55", default-features = false, features = ["runtime"]}
 libc = "0.2"
+glob = "0.3.0"

--- a/redbpf-probes/Cargo.toml
+++ b/redbpf-probes/Cargo.toml
@@ -18,6 +18,7 @@ ufmt = { version = "0.1.0", default-features = false }
 cargo-bpf = { version = "^1.2.0", path = "../cargo-bpf", default-features = false, features = ["bindings"] }
 syn = {version = "1.0", default-features = false, features = ["parsing", "visit"] }
 quote = "1.0"
+glob = "0.3.0"
 
 [dev-dependencies]
 memoffset = "0.5"

--- a/redbpf-probes/build.rs
+++ b/redbpf-probes/build.rs
@@ -38,7 +38,17 @@ pub use {name}::*;
     )
 }
 
+fn rerun_if_changed_dir(dir: &str) {
+    println!("cargo:rerun-if-changed={}/", dir);
+    glob::glob(&format!("./{}/**/*.h", dir))
+        .expect("Failed to glob for source files from build.rs")
+        .filter_map(|e| e.ok())
+        .for_each(|path| println!("cargo:rerun-if-changed={}", path.to_string_lossy()));
+}
+
 fn main() {
+    rerun_if_changed_dir("include");
+
     let out_dir = PathBuf::from(env::var("OUT_DIR").unwrap());
     let types = ["pt_regs", "s32", "bpf_.*"];
     let vars = ["BPF_.*"];

--- a/redbpf-tools/probes/Cargo.toml
+++ b/redbpf-tools/probes/Cargo.toml
@@ -5,6 +5,7 @@ edition = '2018'
 
 [build-dependencies]
 cargo-bpf = { version = "^1.2.0", path = "../../cargo-bpf", default-features = false, features = ["bindings"] }
+glob = "0.3.0"
 
 [dependencies]
 cty = "0.2"

--- a/redbpf-tools/probes/build.rs
+++ b/redbpf-tools/probes/build.rs
@@ -26,7 +26,17 @@ pub use {name}::*;
     )
 }
 
+fn rerun_if_changed_dir(dir: &str) {
+    println!("cargo:rerun-if-changed={}/", dir);
+    glob::glob(&format!("./{}/**/*.h", dir))
+        .expect("Failed to glob for source files from build.rs")
+        .filter_map(|e| e.ok())
+        .for_each(|path| println!("cargo:rerun-if-changed={}", path.to_string_lossy()));
+}
+
 fn main() {
+    rerun_if_changed_dir("include");
+
     if env::var("CARGO_FEATURE_PROBES").is_err() {
         return;
     }


### PR DESCRIPTION
This commit tells `cargo` not to run the `build.rs` scripts in the
following crates if the specified C source files have not changed:

- `redbpf-probes`
- `bpf-sys`
- `redbpf-tools`
- `redbpf-tools/probes`

Prior to this commit `cargo` would re-run the build scripts (which are
generating language bindings to C libraries) on each compile/check. This
drastically slows down the dev cycle, especially if editors want to run
checks after each change/save.

On my desktop Threadripper 2950 (16 cores) with an NVMe drive, the time
spent generating bindings on *every* build was roughly 91 seconds in
debug mode in the worst case. But even cutting out the outlier 
(`redbpf-tools(/probes)`), each crate would be in the 8 second range which 
is still high for certain editors which re-run checks constantly.

This change cuts that wait time out entirely unless the C source files
change.