### PR TITLE
change default TcAction to match upstream

### DIFF
--- a/redbpf-macros/src/lib.rs
+++ b/redbpf-macros/src/lib.rs
@@ -426,7 +426,7 @@ pub fn tc_action(attrs: TokenStream, item: TokenStream) -> TokenStream {
                 Ok(::redbpf_probes::tc::TcAction::Unspec) => -1,
                 Ok(::redbpf_probes::tc::TcAction::Pipe) => 3,
                 Ok(::redbpf_probes::tc::TcAction::Reclassify) => 1,
-                _ => 0
+                Err(_) => -1
             };
 
             #item


### PR DESCRIPTION
This commit changes the default action to match upstream.

Upstream (see `tc-bpf(8)`) denotes `TC_ACT_UNSPEC` (`-1`) as the default
classifier action meaning no classification took place and the packet
should continue processing further up the stack.

Prior to this commit, the default action was `TC_ACT_OK` (`0`) which
terminates the processing pipeline and allows the packet to continue up
the stack.

Context: converstaion about this change took place [on the `redbpf` matrix channel](https://matrix.to/#/!vCJcBZDeGUXaqSvPpL:rustch.at/$O6bKyA7aDWJteuVcuOitm5mc-_tL0VRYynYROT2nolE?via=rustch.at&via=matrix.org&via=petabyte.dev)