### PR TITLE
Fixes zero sized ELF relocations

### DIFF
--- a/redbpf/src/lib.rs
+++ b/redbpf/src/lib.rs
@@ -563,7 +563,7 @@ impl Module {
                 (hdr::SHT_PROGBITS, Some(name), None)
                     if name == ".bss"
                         || name.starts_with(".data")
-                        || name.starts_with(".rodata") =>
+                        || (name.starts_with(".rodata") && content.len() > 0) =>
                 {
                     // load these as ARRAY maps containing one item: the section data. Then during
                     // relocation make instructions point inside the maps.
@@ -729,6 +729,10 @@ impl RelocationInfo {
         let prog = programs.get_mut(&self.target_sec_idx).ok_or(Error::Reloc)?;
         // lookup the symbol we're relocating in the symbol table
         let sym = symtab[self.sym_idx];
+        // If the reloc size is 0, there is nothing to do so we skip
+        if sym.st_size == 0 {
+            return Ok(());
+        }
         // get the map referenced by the program based on the symbol section index
         let map = maps.get(&sym.st_shndx).ok_or(Error::Reloc)?;
 


### PR DESCRIPTION
In some strange circumstances (I'm not sure exactly what triggers it
inside rustc) some sections will be generated with zero size. The loader
API was tripped up by trying to create a map with a value size of 0,
which will always fail verifier checks, since the value size must always
be a mutliple of the element requested (and nothing can be a multiple of
0).

Additionally, even if we don't create the map, the relocation will fail
if the size is 0 because we didn't create a map for it.

This commit fixes both issues, but only for section `.rodata`. If we
later determine that sections such as `.data`, or `.bss` exhibit similar
behavior we can add them to the `content.len() > 0` check.