### PR TITLE
Add an example of socket filter

### DIFF
--- a/examples/example-probes/Cargo.toml
+++ b/examples/example-probes/Cargo.toml
@@ -10,6 +10,7 @@ cargo-bpf = { version = "", path = "../../cargo-bpf", default-features = false, 
 cty = "0.2"
 redbpf-macros = { version = "", path = "../../redbpf-macros" }
 redbpf-probes = { version = "", path = "../../redbpf-probes" }
+memoffset = "0.6.1"
 
 [features]
 default = []
@@ -26,4 +27,10 @@ required-features = ["probes"]
 [[bin]]
 name = "mallocstacks"
 path = "src/mallocstacks/main.rs"
+required-features = ["probes"]
+
+
+[[bin]]
+name = "tcp-lifetime"
+path = "src/tcp_lifetime/main.rs"
 required-features = ["probes"]

--- a/examples/example-probes/src/lib.rs
+++ b/examples/example-probes/src/lib.rs
@@ -1,3 +1,4 @@
 #![no_std]
 pub mod mallocstacks;
+pub mod tcp_lifetime;
 pub mod vfsreadlat;

--- a/examples/example-probes/src/tcp_lifetime/main.rs
+++ b/examples/example-probes/src/tcp_lifetime/main.rs
@@ -1,0 +1,77 @@
+// This program can be executed by
+// # cargo run --example tcp-lifetime [interface]
+#![no_std]
+#![no_main]
+use core::mem::{self, MaybeUninit};
+use memoffset::offset_of;
+
+use redbpf_probes::socket_filter::prelude::*;
+
+use example_probes::tcp_lifetime::{SocketAddr, TCPLifetime};
+
+#[map(link_section = "maps/established")]
+static mut ESTABLISHED: HashMap<(SocketAddr, SocketAddr), u64> = HashMap::with_max_entries(10240);
+
+#[map(link_section = "maps/tcp_lifetime")]
+static mut TCP_LIFETIME: PerfMap<TCPLifetime> = PerfMap::with_max_entries(10240);
+
+program!(0xFFFFFFFE, "GPL");
+#[socket_filter]
+fn measure_tcp_lifetime(skb: SkBuff) -> SkBuffResult {
+    let eth_len = mem::size_of::<ethhdr>();
+    let eth_proto = skb.load::<__be16>(offset_of!(ethhdr, h_proto))? as u32;
+    if eth_proto != ETH_P_IP {
+        return Ok(SkBuffAction::Ignore);
+    }
+
+    let ip_proto = skb.load::<__u8>(eth_len + offset_of!(iphdr, protocol))? as u32;
+    if ip_proto != IPPROTO_TCP {
+        return Ok(SkBuffAction::Ignore);
+    }
+
+    let mut ip_hdr = unsafe { MaybeUninit::<iphdr>::zeroed().assume_init() };
+    ip_hdr._bitfield_1 = __BindgenBitfieldUnit::new([skb.load::<u8>(eth_len)?]);
+    if ip_hdr.version() != 4 {
+        return Ok(SkBuffAction::Ignore);
+    }
+
+    let ihl = ip_hdr.ihl() as usize;
+    let src = SocketAddr::new(
+        skb.load::<__be32>(eth_len + offset_of!(iphdr, saddr))?,
+        skb.load::<__be16>(eth_len + ihl * 4 + offset_of!(tcphdr, source))?,
+    );
+    let dst = SocketAddr::new(
+        skb.load::<__be32>(eth_len + offset_of!(iphdr, daddr))?,
+        skb.load::<__be16>(eth_len + ihl * 4 + offset_of!(tcphdr, dest))?,
+    );
+    let pair = (src, dst);
+    let mut tcp_hdr = unsafe { MaybeUninit::<tcphdr>::zeroed().assume_init() };
+    tcp_hdr._bitfield_1 = __BindgenBitfieldUnit::new([
+        skb.load::<u8>(eth_len + ihl * 4 + offset_of!(tcphdr, _bitfield_1))?,
+        skb.load::<u8>(eth_len + ihl * 4 + offset_of!(tcphdr, _bitfield_1) + 1)?,
+    ]);
+
+    if tcp_hdr.syn() == 1 {
+        unsafe {
+            ESTABLISHED.set(&pair, &bpf_ktime_get_ns());
+        }
+    }
+
+    if tcp_hdr.fin() == 1 || tcp_hdr.rst() == 1 {
+        unsafe {
+            if let Some(estab_ts) = ESTABLISHED.get(&pair) {
+                ESTABLISHED.delete(&pair);
+                TCP_LIFETIME.insert(
+                    skb.skb as *mut __sk_buff,
+                    &TCPLifetime {
+                        src,
+                        dst,
+                        duration: bpf_ktime_get_ns() - estab_ts,
+                    },
+                );
+            }
+        }
+    }
+
+    Ok(SkBuffAction::Ignore)
+}

--- a/examples/example-probes/src/tcp_lifetime/mod.rs
+++ b/examples/example-probes/src/tcp_lifetime/mod.rs
@@ -1,0 +1,39 @@
+use ::core::fmt;
+use ::core::mem::transmute;
+
+#[derive(Copy, Clone)]
+#[repr(C)]
+pub struct SocketAddr {
+    pub addr: u32,
+    pub port: u16,
+    _padding: u16,
+}
+
+#[repr(C)]
+pub struct TCPLifetime {
+    pub src: SocketAddr,
+    pub dst: SocketAddr,
+    pub duration: u64,
+}
+
+impl fmt::Display for SocketAddr {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        let octets: [u8; 4] = unsafe { transmute::<u32, [u8; 4]>(self.addr) };
+
+        write!(
+            f,
+            "{:^3}.{:^3}.{:^3}.{:^3}:{:<5}",
+            octets[3], octets[2], octets[1], octets[0], self.port
+        )
+    }
+}
+
+impl SocketAddr {
+    pub fn new(addr: u32, port: u16) -> Self {
+        SocketAddr {
+            addr,
+            port,
+            _padding: 0,
+        }
+    }
+}

--- a/examples/example-userspace/examples/tcp-lifetime.rs
+++ b/examples/example-userspace/examples/tcp-lifetime.rs
@@ -1,0 +1,97 @@
+// This program can be executed by
+// # cargo run --example tcp-lifetime [interface]
+// It reports (saddr, sport, daddr, dport, lifetime) of which established and
+// closed while the program is running.
+
+// Example of execution
+// $ sudo -E cargo run --example tcp-lifetime wlp0s20f3
+// Attaching socket to interface wlp0s20f3
+// Hit Ctrl-C to quit
+//          src           →           dst          |  duration
+// 192.168. 0 . 9 :36940  →   8 . 8 . 8 . 8 :53    |     1303 ms
+//  8 . 8 . 8 . 8 :53     →  192.168. 0 . 9 :36940 |     1304 ms
+
+use futures::stream::StreamExt;
+use std::env;
+
+use std::process;
+use std::ptr;
+use tokio::signal::ctrl_c;
+
+use redbpf::load::Loader;
+use redbpf::HashMap;
+
+use probes::tcp_lifetime::{SocketAddr, TCPLifetime};
+
+#[tokio::main]
+async fn main() {
+    if unsafe { libc::getuid() != 0 } {
+        eprintln!("You must be root to use eBPF!");
+        process::exit(1);
+    }
+
+    let args: Vec<String> = env::args().collect();
+    let iface = match args.get(1) {
+        Some(val) => val,
+        None => "lo",
+    };
+    println!("Attaching socket to interface {}", iface);
+    let mut raw_fds = Vec::new();
+    let mut loaded = Loader::load(probe_code()).expect("error loading BPF program");
+    for sf in loaded.socket_filters_mut() {
+        if let Ok(sock_raw_fd) = sf.attach_socket_filter(iface) {
+            raw_fds.push(sock_raw_fd);
+        }
+    }
+
+    let event_fut = async {
+        println!("{:^21}  →  {:^21} | {:^11}", "src", "dst", "duration");
+        while let Some((name, events)) = loaded.events.next().await {
+            match name.as_str() {
+                "tcp_lifetime" => {
+                    for event in events {
+                        let tcp_lifetime =
+                            unsafe { ptr::read(event.as_ptr() as *const TCPLifetime) };
+                        println!(
+                            "{:21}  →  {:21} | {:>8} ms",
+                            tcp_lifetime.src.to_string(),
+                            tcp_lifetime.dst.to_string(),
+                            tcp_lifetime.duration / 1000 / 1000
+                        );
+                    }
+                }
+                _ => {
+                    eprintln!("unknown event = {}", name);
+                }
+            }
+        }
+    };
+    let ctrlc_fut = async {
+        ctrl_c().await.unwrap();
+    };
+    println!("Hit Ctrl-C to quit");
+    tokio::select! {
+        _ = event_fut => {
+
+        }
+        _ = ctrlc_fut => {
+            println!("");
+        }
+    }
+    let estab: HashMap<(SocketAddr, SocketAddr), u64> =
+        HashMap::new(loaded.map("established").unwrap()).unwrap();
+    for ((src, dst), _) in estab.iter() {
+        println!(
+            "{:<21}  →  {:<21} | still established",
+            src.to_string(),
+            dst.to_string()
+        );
+    }
+}
+
+fn probe_code() -> &'static [u8] {
+    include_bytes!(concat!(
+        env!("OUT_DIR"),
+        "/target/bpf/programs/tcp-lifetime/tcp-lifetime.elf"
+    ))
+}

--- a/redbpf-probes/src/socket_filter/prelude.rs
+++ b/redbpf-probes/src/socket_filter/prelude.rs
@@ -18,4 +18,4 @@ pub use crate::maps::*;
 pub use crate::socket::*;
 pub use crate::socket_filter::*;
 pub use cty::*;
-pub use redbpf_macros::{program, socket_filter};
+pub use redbpf_macros::{map, program, socket_filter};


### PR DESCRIPTION
This example describes how to write an eBPF program and a user-space
program which make use of socket filter.

It captures SYN packets and stores current timestamp into a map. When it
finds FIN or RST packets, it calculates TCP lifetime by subtracting the
timestamp stored at the map from the current timestamp.
