### PR TITLE
Tracepoint

### DIFF
--- a/redbpf-macros/Cargo.toml
+++ b/redbpf-macros/Cargo.toml
@@ -13,9 +13,10 @@ license = "MIT OR Apache-2.0"
 proc-macro = true
 
 [dependencies]
+heck = "0.3.2"
 proc-macro2 = "1.0"
-syn = {version = "1.0", features = ["full"] }
 quote = "1.0"
+syn = { version = "1.0", features = ["full"] }
 
 [build-dependencies]
 rustc_version = "0.3.0"

--- a/redbpf-probes/src/lib.rs
+++ b/redbpf-probes/src/lib.rs
@@ -59,5 +59,6 @@ pub mod registers;
 pub mod socket;
 pub mod socket_filter;
 pub mod tc;
+pub mod tracepoint;
 pub mod uprobe;
 pub mod xdp;

--- a/redbpf-probes/src/tracepoint/mod.rs
+++ b/redbpf-probes/src/tracepoint/mod.rs
@@ -8,13 +8,9 @@
 /*!
 Tracepoint probes.
 
-KProbes are hooks on the entry (kprobe) or exit (kretprobe) of a kernel function.
-For an overview of KProbes and how they work, see
-<https://www.kernel.org/doc/Documentation/kprobes.txt>.
-
 # Example
 
-Do something when `execve` is called.
+Do something when a syscall is started.
 
 ```no_run
 #![no_std]

--- a/redbpf-probes/src/tracepoint/mod.rs
+++ b/redbpf-probes/src/tracepoint/mod.rs
@@ -1,0 +1,33 @@
+// Copyright 2019 Authors of Red Sift
+//
+// Licensed under the Apache License, Version 2.0, <LICENSE-APACHE or
+// http://apache.org/licenses/LICENSE-2.0> or the MIT license <LICENSE-MIT or
+// http://opensource.org/licenses/MIT>, at your option. This file may not be
+// copied, modified, or distributed except according to those terms.
+
+/*!
+Tracepoint probes.
+
+KProbes are hooks on the entry (kprobe) or exit (kretprobe) of a kernel function.
+For an overview of KProbes and how they work, see
+<https://www.kernel.org/doc/Documentation/kprobes.txt>.
+
+# Example
+
+Do something when `execve` is called.
+
+```no_run
+#![no_std]
+#![no_main]
+use redbpf_probes::tracepoint::prelude::*;
+
+program!(0xFFFFFFFE, "GPL");
+
+#[tracepoint("raw_syscalls:syscall_enter")]
+pub fn syscall_enter(args: *const core::ffi::c_void) {
+    // do something here
+    // ...
+}
+```
+ */
+pub mod prelude;

--- a/redbpf-probes/src/tracepoint/prelude.rs
+++ b/redbpf-probes/src/tracepoint/prelude.rs
@@ -1,0 +1,21 @@
+// Copyright 2019-2020 Authors of Red Sift
+//
+// Licensed under the Apache License, Version 2.0, <LICENSE-APACHE or
+// http://apache.org/licenses/LICENSE-2.0> or the MIT license <LICENSE-MIT or
+// http://opensource.org/licenses/MIT>, at your option. This file may not be
+// copied, modified, or distributed except according to those terms.
+
+//! The Tracepoint Prelude
+//!
+//! The purpose of this module is to alleviate imports of the common tracepoint types
+//! by adding a glob import to the top of tracepoint programs:
+//!
+//! ```
+//! use redbpf_probes::tracepoint::prelude::*;
+//! ```
+pub use cty::*;
+pub use redbpf_macros::{tracepoint, map, program};
+pub use crate::bindings::*;
+pub use crate::helpers::*;
+pub use crate::maps::*;
+pub use crate::registers::*;

--- a/redbpf/src/load/loader.rs
+++ b/redbpf/src/load/loader.rs
@@ -14,7 +14,7 @@ use std::path::Path;
 
 use crate::{Program, cpus};
 use crate::load::map_io::PerfMessageStream;
-use crate::{Error, KProbe, Map, Module, PerfMap, SocketFilter, UProbe, XDP};
+use crate::{Error, KProbe, Map, Module, PerfMap, SocketFilter, UProbe, TracePoint, XDP};
 
 #[derive(Debug)]
 pub enum LoaderError {
@@ -119,5 +119,9 @@ impl Loaded {
 
     pub fn socket_filters_mut(&mut self) -> impl Iterator<Item = &mut SocketFilter> {
         self.module.socket_filters_mut()
+    }
+
+    pub fn tracepoints_mut(&mut self) -> impl Iterator<Item = &mut TracePoint> {
+        self.module.tracepoints_mut()
     }
 }


### PR DESCRIPTION
Makes support for tracepoints usable.

```rust
#[map("syscall_count")]
static mut COUNT: HashMap<u32, u32> = HashMap::with_max_entries(10240);

#[tracepoint("raw_syscalls:sys_enter")]
fn sys_enter(args: &SysEnter) {
    let count = unsafe { COUNT.get(&args.id) }.unwrap_or_default();
    unsafe { COUNT.set(&args.id, count + 1); }
}
```