### PR TITLE
Move MapBtf structures to the maps.ext section

### DIFF
--- a/redbpf-macros/src/lib.rs
+++ b/redbpf-macros/src/lib.rs
@@ -264,6 +264,8 @@ pub fn map(attrs: TokenStream, item: TokenStream) -> TokenStream {
         let mod_ident = syn::Ident::new(&mod_name, static_item.ident.span());
         let ktype = key_type.unwrap();
         let vtype = value_type.unwrap();
+        let map_btf_name = format!("MAP_BTF_{}", static_item.ident.to_string());
+        let map_btf_ident = syn::Ident::new(&map_btf_name, static_item.ident.span());
         tokens.extend(quote! {
             mod #mod_ident {
                 #[allow(unused_imports)]
@@ -278,9 +280,9 @@ pub fn map(attrs: TokenStream, item: TokenStream) -> TokenStream {
                 // `impl Sync` is needed to allow pointer types of keys and values
                 unsafe impl Sync for MapBtf {}
                 const N: usize = mem::size_of::<MapBtf>();
-                #[used]
-                #[link_section = #section_name]
-                static MAP_BTF: MapBtf = unsafe { mem::transmute::<[u8; N], MapBtf>([0u8; N])};
+                #[no_mangle]
+                #[link_section = "maps.ext"]
+                static #map_btf_ident: MapBtf = unsafe { mem::transmute::<[u8; N], MapBtf>([0u8; N]) };
             }
         });
     }


### PR DESCRIPTION
A MapBtf structure has been appended right after the bpf_map_def
structure. But this prohibits multiple maps from being defined in one
section. But the `maps` section should be able to accommodate multiple
maps. For example, all `TcHashMap`s should be defined in the `maps`
section. This restriction is required by tc utility.

Define all MapBtf structures in the `maps.ext` section so that multiple
`bpf_map_def` structures can be put together without interleaved MapBtf
structures.

Normally only one map is defined in a section. But defining more than
one maps in a section is semantically ambiguous. Because the name of the
section represents the name of the map. So sections of which name is
`maps/<name>` are not allowed to hold more than one bpf_map_def. Only
`maps` section is allowed to have multiple maps.

Signed-off-by: Junyeong Jeong <rhdxmr@gmail.com>