### PR TITLE
Bump version 2.1.0

### DIFF
--- a/TUTORIAL.md
+++ b/TUTORIAL.md
@@ -299,7 +299,7 @@ Cargo.toml  probes/  src/  target/
 Open `Cargo.toml` with your favorite editor and add dependencies:
 
 ```toml
-redbpf = { version = "2.0", features = ["load"] }
+redbpf = { version = "2.1.0", features = ["load"] }
 tokio = { version = "1.0", features = ["rt", "signal", "time", "io-util", "net", "sync"] }
 tracing-subscriber = "0.2"
 tracing = "0.1"

--- a/bpf-sys/Cargo.toml
+++ b/bpf-sys/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "bpf-sys"
-version = "2.0.2"
+version = "2.1.0"
 description = "Bindings for libbpf"
 repository = "https://github.com/foniod/redbpf"
 documentation = "https://foniod.org/api/bpf_sys/"

--- a/cargo-bpf/Cargo.toml
+++ b/cargo-bpf/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cargo-bpf"
-version = "2.0.2"
+version = "2.1.0"
 description = "Cargo plugin to manage eBPF probes using redbpf"
 repository = "https://github.com/foniod/redbpf"
 documentation = "https://foniod.org/api/cargo_bpf/"
@@ -21,8 +21,8 @@ required-features = ["command-line"]
 clap = { version = "2.33", optional = true }
 bindgen = {version = "0.59.1", default-features = false, features = ["runtime"], optional = true}
 toml_edit = { version = "0.2", optional = true }
-bpf-sys = { version = "2.0.2", path = "../bpf-sys", optional = true }
-redbpf = { version = "2.0.2", path = "../redbpf", default-features = false, optional = true }
+bpf-sys = { version = "2.1.0", path = "../bpf-sys", optional = true }
+redbpf = { version = "2.1.0", path = "../redbpf", default-features = false, optional = true }
 futures = { version = "0.3", optional = true }
 tokio = { version = "^1.0.1", features = ["rt", "macros", "signal"], optional = true }
 hexdump = { version = "0.1", optional = true }

--- a/cargo-bpf/src/new.rs
+++ b/cargo-bpf/src/new.rs
@@ -31,11 +31,11 @@ edition = '2018'
 
 [dependencies]
 cty = "0.2"
-redbpf-macros = "2.0"
-redbpf-probes = "2.0"
+redbpf-macros = "2.1.0"
+redbpf-probes = "2.1.0"
 
 [build-dependencies]
-cargo-bpf = {{ version = "2.0", default-features = false }}
+cargo-bpf = {{ version = "2.1.0", default-features = false }}
 
 [features]
 default = []

--- a/redbpf-macros/Cargo.toml
+++ b/redbpf-macros/Cargo.toml
@@ -4,7 +4,7 @@ description = "Procedural macros for redbpf"
 repository = "https://github.com/foniod/redbpf"
 documentation = "https://foniod.org/api/redbpf_macros/"
 authors = ["Alessandro Decina <alessandro.d@gmail.com>", "Peter Parkanyi <p@symmetree.dev>", "Junyeong Jeong <rhdxmr@gmail.com>"]
-version = "2.0.2"
+version = "2.1.0"
 edition = '2018'
 keywords = ["bpf", "ebpf", "redbpf"]
 license = "MIT OR Apache-2.0"
@@ -23,6 +23,6 @@ rustc_version = "0.3.0"
 
 [dev-dependencies]
 # redbpf-probes is needed by doctests
-redbpf-probes = { version = "2.0.2", path = "../redbpf-probes" }
+redbpf-probes = { version = "2.1.0", path = "../redbpf-probes" }
 # memoffset is needed by doctests
 memoffset = "0.6"

--- a/redbpf-probes/Cargo.toml
+++ b/redbpf-probes/Cargo.toml
@@ -4,19 +4,19 @@ description = "eBPF probe-related types for redbpf"
 repository = "https://github.com/foniod/redbpf"
 documentation = "https://foniod.org/api/redbpf_probes/"
 authors = ["Alessandro Decina <alessandro.d@gmail.com>", "Peter Parkanyi <p@symmetree.dev>", "Junyeong Jeong <rhdxmr@gmail.com>"]
-version = "2.0.2"
+version = "2.1.0"
 edition = '2018'
 keywords = ["bpf", "ebpf", "redbpf"]
 license = "MIT OR Apache-2.0"
 
 [dependencies]
 cty = "0.2"
-redbpf-macros = { version = "2.0.2", path = "../redbpf-macros" }
+redbpf-macros = { version = "2.1.0", path = "../redbpf-macros" }
 ufmt = { version = "0.1.0", default-features = false }
 
 [build-dependencies]
-cargo-bpf = { version = "2.0.2", path = "../cargo-bpf", default-features = false, features = ["bindings"] }
-bpf-sys = { version = "2.0.2", path = "../bpf-sys" }
+cargo-bpf = { version = "2.1.0", path = "../cargo-bpf", default-features = false, features = ["bindings"] }
+bpf-sys = { version = "2.1.0", path = "../bpf-sys" }
 syn = {version = "1.0", default-features = false, features = ["parsing", "visit"] }
 quote = "1.0"
 glob = "0.3.0"

--- a/redbpf/Cargo.toml
+++ b/redbpf/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "redbpf"
-version = "2.0.2"
+version = "2.1.0"
 description = "eBPF build and runtime library"
 repository = "https://github.com/foniod/redbpf"
 documentation = "https://foniod.org/api/redbpf/"
@@ -14,7 +14,7 @@ readme = "README.md"
 maintenance = { status = "actively-developed" }
 
 [dependencies]
-bpf-sys = { path = "../bpf-sys", version = "2.0.2" }
+bpf-sys = { path = "../bpf-sys", version = "2.1.0" }
 goblin = "0.4"
 zero = "0.1"
 libc = "0.2"

--- a/scripts/bump-version.sh
+++ b/scripts/bump-version.sh
@@ -14,3 +14,7 @@ find $PACKAGES -name Cargo.toml -type f -exec sed -i -e "s/^version.*/version = 
 find $PACKAGES -name Cargo.toml -type f -exec sed -i -e "s/^\(bpf-sys.*version = \)\"[^\"]*\"/\\1\"$NEW_VERSION\"/" {} \;
 find $PACKAGES -name Cargo.toml -type f -exec sed -i -e "s/^\(cargo-bpf.*version = \)\"[^\"]*\"/\\1\"$NEW_VERSION\"/" {} \;
 find $PACKAGES -name Cargo.toml -type f -exec sed -i -e "s/^\(redbpf.*version = \)\"[^\"]*\"/\\1\"$NEW_VERSION\"/" {} \;
+
+sed -i -r -e 's/^(redbpf-(macros|probes) = )"[^"]+"/\1"'$NEW_VERSION'"/' \
+    -e 's/^(cargo-bpf =.*version = )"[^"]+"/\1"'$NEW_VERSION'"/' cargo-bpf/src/new.rs
+sed -i -r -e 's/^(redbpf =.*version = )"[^"]+"/\1"'$NEW_VERSION'"/' TUTORIAL.md


### PR DESCRIPTION
I think it is time to release redbpf 2.1.0.
It would be nice to do it after LLVM13 support PR #209 is merged.

Signed-off-by: Junyeong Jeong <rhdxmr@gmail.com>