### PR TITLE
Fix for tasks example to compile when using kernal5_8 feature

### DIFF
--- a/redbpf-probes/include/bpf_iter.h
+++ b/redbpf-probes/include/bpf_iter.h
@@ -1,5 +1,6 @@
 #ifndef __BPF_ITER_H__
 #define __BPF_ITER_H__
+
 #undef bpf_iter__task
 struct bpf_iter__task {
         union {
@@ -9,4 +10,14 @@ struct bpf_iter__task {
                 struct task_struct *task;
         };
 };
+
+#undef bpf_iter_meta
+struct bpf_iter_meta {
+        union {
+                struct seq_file *seq;
+        };
+        u64 session_id;
+        u64 seq_num;
+};
+
 #endif  // __BPF_ITER_H__


### PR DESCRIPTION
When attempting to compile examples with Kernel v5.13, I was getting the following error

```
     Compiling example-probes v0.1.0 (/Work/fly-io-coding-challenge/36800/redbpf/examples/example-probes)
  warning: due to multiple output types requested, the explicitly specified output file name will be adapted for each output type
 warning: ignoring --out-dir flag due to -o flag

  error[E0609]: no field `__bindgen_anon_1` on type `bpf_iter_meta`
    --> examples/example-probes/src/tasks/main.rs:12:31
     |
  12 |     let seq_ptr = (*meta_ptr).__bindgen_anon_1.seq;
     |                               ^^^^^^^^^^^^^^^^ unknown field
     |
     = note: available fields are: `_address`

  For more information about this error, try `rustc --explain E0609`.
  warning: `example-probes` (bin "tasks") generated 2 warnings
  error: could not compile `example-probes` due to previous error; 2 warnings emitted
```

I was using the command:

```
cargo build --no-default-features --features llvm13,kernel5_8 --examples
```

This change allowed the `tasks` example to compile and execute for me -- although there may be a more appropriate fix?
