### PR TITLE
Fixes SockMap.value_size so that sockmaps can be dumped by bpftool

### DIFF
--- a/redbpf-probes/src/maps.rs
+++ b/redbpf-probes/src/maps.rs
@@ -501,7 +501,7 @@ impl SockMap {
             def: bpf_map_def {
                 type_: bpf_map_type_BPF_MAP_TYPE_SOCKMAP,
                 key_size: mem::size_of::<i32>() as u32,
-                value_size: mem::size_of::<i32>() as u32,
+                value_size: mem::size_of::<i64>() as u32,
                 max_entries,
                 map_flags: 0,
             },

--- a/redbpf/src/lib.rs
+++ b/redbpf/src/lib.rs
@@ -2615,12 +2615,13 @@ impl<'a> SockMap<'a> {
         Ok(SockMap { base: map })
     }
 
-    pub fn set(&mut self, mut idx: u32, mut fd: RawFd) -> Result<()> {
+    pub fn set(&mut self, mut idx: u32, fd: RawFd) -> Result<()> {
+        let mut value = fd as u64;
         let ret = unsafe {
             bpf_sys::bpf_map_update_elem(
                 self.base.fd,
                 &mut idx as *mut _ as *mut _,
-                &mut fd as *mut _ as *mut _,
+                &mut value as *mut _ as *mut _,
                 BPF_ANY.into(), // No condition on the existence of the entry for `idx`.
             )
         };


### PR DESCRIPTION
`bpftool` reports a cryptic "No space left on device" error when attempting to dump a `SockMap`

![image](https://user-images.githubusercontent.com/405366/142597221-5cdac224-9ec1-4897-8965-15fa56da74c9.png)

This is because the `value_size` is `4B` -- it needs to be `8B` to work with `bpftool`.

With this change, the commands look like:

![image](https://user-images.githubusercontent.com/405366/142596950-9c55da11-3695-4dbe-b7a0-33c00f1a96ae.png)
