### PR TITLE
Adds sk_lookup socket steering example

### DIFF
--- a/examples/example-probes/Cargo.toml
+++ b/examples/example-probes/Cargo.toml
@@ -25,6 +25,7 @@ memoffset = "0.6.1"
 default = []
 probes = []
 kernel5_8 = []
+kernel5_9 = ["kernel5_8"]
 
 [lib]
 path = "src/lib.rs"
@@ -78,3 +79,8 @@ required-features = ["probes", "kernel5_8"]
 name = "hashmaps"
 path = "src/hashmaps/main.rs"
 required-features = ["probes"]
+
+[[bin]]
+name = "socket_steering"
+path = "src/socket_steering/main.rs"
+required-features = ["probes", "kernel5_9"]

--- a/examples/example-probes/src/socket_steering/main.rs
+++ b/examples/example-probes/src/socket_steering/main.rs
@@ -1,0 +1,25 @@
+#![no_std]
+#![no_main]
+
+use redbpf_probes::sk_lookup::prelude::*;
+
+program!(0xFFFFFFFE, "GPL");
+
+#[map]
+static mut steered_ports: HashMap<u16, u8> = HashMap::with_max_entries(1024);
+
+#[map]
+static mut destination_socket: SockMap = SockMap::with_max_entries(1);
+
+#[sk_lookup]
+pub fn steer_to_socket(ctx: SkLookupContext) -> SkAction {
+    unsafe {
+        if steered_ports.get(&ctx.local_port()).is_some()
+            && destination_socket.assign(ctx.inner(), 0).is_err()
+        {
+            SkAction::Drop
+        } else {
+            SkAction::Pass
+        }
+    }
+}

--- a/examples/example-userspace/Cargo.toml
+++ b/examples/example-userspace/Cargo.toml
@@ -26,8 +26,14 @@ name = "tasks"
 path = "examples/tasks.rs"
 required-features = ["kernel5_8"]  # bpf iterator has been supported since kernel v5.8
 
+[[example]]
+name = "socket-steering"
+path = "examples/socket-steering.rs"
+required-features = ["kernel5_9"]  # bpf sk_lookup has been supported since kernel v5.9
+
 [features]
 kernel5_8 = []
+kernel5_9 = ["kernel5_8"]
 default = ["llvm12"]
 llvm13 = ["cargo-bpf/llvm13"]
 llvm12 = ["cargo-bpf/llvm12"]

--- a/examples/example-userspace/build.rs
+++ b/examples/example-userspace/build.rs
@@ -12,6 +12,10 @@ fn main() {
     if env::var("CARGO_FEATURE_KERNEL5_8").is_ok() {
         features.push(String::from("kernel5_8"));
     }
+    if env::var("CARGO_FEATURE_KERNEL5_9").is_ok() {
+        features.push(String::from("kernel5_8"));
+        features.push(String::from("kernel5_9"));
+    }
     cargo_bpf::build_with_features(
         &cargo,
         &probes,

--- a/examples/example-userspace/examples/socket-steering.rs
+++ b/examples/example-userspace/examples/socket-steering.rs
@@ -1,0 +1,92 @@
+/// This example shows how to steer connections to sockets using BPF socket lookup hook.
+///
+/// It's a Rust implementation of the following presentation:
+/// https://ebpf.io/summit-2020-slides/eBPF_Summit_2020-Lightning-Jakub_Sitnicki-Steering_connections_to_sockets_with_BPF_socke_lookup_hook.pdf
+///
+/// Example usage:
+///    cargo build --no-default-features --features llvm13,kernel5_9 --example socket-steering
+///    sudo -Es $(which cargo) run --no-default-features --features llvm13,kernel5_9 --example socket-steering 7 77 777
+///
+use redbpf::{HashMap, SockMap};
+use redbpf::load::Loader;
+use std::{env, net::SocketAddr, os::unix::io::AsRawFd, process};
+use tokio::net::TcpListener;
+use tokio::task::{self, LocalSet};
+use tokio::{io, signal};
+use tracing::{debug, error, Level};
+use tracing_subscriber::FmtSubscriber;
+
+#[tokio::main(flavor = "current_thread")]
+async fn main() {
+    let subscriber = FmtSubscriber::builder()
+        .with_max_level(Level::TRACE)
+        .finish();
+    tracing::subscriber::set_global_default(subscriber).unwrap();
+    if unsafe { libc::getuid() != 0 } {
+        error!("You must be root to use eBPF!");
+        process::exit(1);
+    }
+
+    let ports = env::args()
+        .skip(1)
+        .map(|s| {
+            s.parse::<u16>()
+                .expect(format!("Unable to convert {} to u16", s).as_str())
+        })
+        .collect::<Vec<u16>>();
+    if ports.is_empty() {
+        error!("Specify port numbers to steer");
+        process::exit(1);
+    }
+
+    debug!("Load steer_to_socket BPF program code");
+    let mut loaded = Loader::load(probe_code()).unwrap();
+
+    debug!("Attaching steer_to_socket BPF program");
+    loaded
+        .sk_lookup_mut("steer_to_socket")
+        .unwrap()
+        .attach_sk_lookup("/proc/self/ns/net")
+        .unwrap();
+
+    debug!("Listen on 0.0.0.0:8007");
+    let listener = TcpListener::bind(SocketAddr::from(([0, 0, 0, 0], 8007)))
+        .await
+        .unwrap();
+    let listener_fd = listener.as_raw_fd();
+
+    debug!("Pass the listener fd {} to the BPF program", listener_fd);
+    let destination_socket_map = loaded.map("destination_socket").unwrap();
+    let mut destination_socket = SockMap::new(destination_socket_map).unwrap();
+    destination_socket.set(0, listener_fd).unwrap();
+
+    debug!("Pass the steered ports to the BPF program");
+    let steered_ports_map = loaded.map("steered_ports").unwrap();
+    let steered_ports = HashMap::<u16, u8>::new(steered_ports_map).unwrap();
+    for port in ports {
+        steered_ports.set(port, 1);
+    }
+
+    debug!("Echoing received data");
+    let local = LocalSet::new();
+    local.spawn_local(async move {
+        loop {
+            let (mut tcp_stream, client_addr) = listener.accept().await.unwrap();
+            debug!("New client: {}", client_addr);
+            task::spawn_local(async move {
+                let (mut reader, mut writer) = tcp_stream.split();
+                io::copy(&mut reader, &mut writer).await.unwrap();
+            });
+        }
+    });
+
+    debug!("Hit Ctrl-C to quit");
+    let _ = local.run_until(signal::ctrl_c()).await;
+}
+
+fn probe_code() -> &'static [u8] {
+    include_bytes!(concat!(
+        env!("OUT_DIR"),
+        "/target/bpf/programs/socket_steering/socket_steering.elf"
+    ))
+}

--- a/redbpf-macros/src/lib.rs
+++ b/redbpf-macros/src/lib.rs
@@ -717,3 +717,27 @@ pub fn task_iter(attrs: TokenStream, item: TokenStream) -> TokenStream {
 
     probe_impl("task_iter", attrs, wrapper, name)
 }
+
+/// Define [sk_lookup BPF programs](https://www.kernel.org/doc/Documentation/bpf/prog_sk_lookup.rst)
+#[proc_macro_attribute]
+pub fn sk_lookup(attrs: TokenStream, item: TokenStream) -> TokenStream {
+    let item = parse_macro_input!(item as ItemFn);
+    let name = item.sig.ident.to_string();
+    let ident = item.sig.ident.clone();
+    let outer_ident = Ident::new(&format!("outer_{}", ident), Span::call_site());
+    let wrapper = parse_quote! {
+        fn #outer_ident(ctx: *mut ::redbpf_probes::bindings::bpf_sk_lookup) -> i32 {
+            let ctx = ::redbpf_probes::sk_lookup::SkLookupContext { ctx };
+            use ::redbpf_probes::socket::SkAction;
+
+            return match unsafe { #ident(ctx) } {
+                SkAction::Pass => ::redbpf_probes::bindings::sk_action_SK_PASS,
+                SkAction::Drop => ::redbpf_probes::bindings::sk_action_SK_DROP,
+            } as i32;
+
+            #item
+        }
+    };
+
+    probe_impl("sk_lookup", attrs, wrapper, name)
+}

--- a/redbpf-probes/src/lib.rs
+++ b/redbpf-probes/src/lib.rs
@@ -109,6 +109,7 @@ pub mod kprobe;
 pub mod maps;
 pub mod net;
 pub mod registers;
+pub mod sk_lookup;
 pub mod socket;
 pub mod socket_filter;
 pub mod sockmap;

--- a/redbpf-probes/src/sk_lookup/mod.rs
+++ b/redbpf-probes/src/sk_lookup/mod.rs
@@ -1,0 +1,52 @@
+pub mod prelude;
+
+use crate::bindings::*;
+
+#[derive(Clone)]
+pub struct SkLookupContext {
+    pub ctx: *mut bpf_sk_lookup,
+}
+
+impl SkLookupContext {
+    /// Returns the raw `bpf_sk_lookup` context passed by the kernel.
+    #[inline]
+    pub fn inner(&self) -> *mut bpf_sk_lookup {
+        self.ctx
+    }
+
+    pub fn family(&self) -> u32 {
+        unsafe { (*self.ctx).family }
+    }
+
+    pub fn protocol(&self) -> u32 {
+        unsafe { (*self.ctx).protocol }
+    }
+
+    pub fn remote_ip4(&self) -> u32 {
+        unsafe { (*self.ctx).remote_ip4 }
+    }
+
+    pub fn remote_ip6(&self) -> [u32; 4] {
+        unsafe { (*self.ctx).remote_ip6 }
+    }
+
+    pub fn remote_port(&self) -> u16 {
+        // ctx.remote_port is u32, however highest port number is currently 2^16 - 1
+        // useful to return as u16 to reduce memory reqs of large hash maps of ports
+        unsafe { (*self.ctx).remote_port as u16 }
+    }
+
+    pub fn local_ip4(&self) -> u32 {
+        unsafe { (*self.ctx).local_ip4 }
+    }
+
+    pub fn local_ip6(&self) -> [u32; 4] {
+        unsafe { (*self.ctx).local_ip6 }
+    }
+
+    pub fn local_port(&self) -> u16 {
+        // ctx.local_port is u32, however highest port number is currently 2^16 - 1
+        // useful to return as u16 to reduce memory reqs of large hash maps of ports
+        unsafe { (*self.ctx).local_port as u16 }
+    }
+}

--- a/redbpf-probes/src/sk_lookup/prelude.rs
+++ b/redbpf-probes/src/sk_lookup/prelude.rs
@@ -1,0 +1,21 @@
+// Copyright 2019-2020 Authors of Red Sift
+//
+// Licensed under the Apache License, Version 2.0, <LICENSE-APACHE or
+// http://apache.org/licenses/LICENSE-2.0> or the MIT license <LICENSE-MIT or
+// http://opensource.org/licenses/MIT>, at your option. This file may not be
+// copied, modified, or distributed except according to those terms.
+//! The Socket Filter Prelude
+//!
+//! The purpose of this module is to alleviate imports of the common Socket
+//! Filter types by adding a glob import to the top of Socket Filter programs:
+//!
+//! ```
+//! use redbpf_probes::socket_filter::prelude::*;
+//! ```
+pub use crate::bindings::*;
+pub use crate::helpers::*;
+pub use crate::maps::*;
+pub use crate::sk_lookup::*;
+pub use crate::socket::*;
+pub use cty::*;
+pub use redbpf_macros::{map, program, sk_lookup};

--- a/scripts/build-test.sh
+++ b/scripts/build-test.sh
@@ -40,7 +40,7 @@ ubuntu-20.04() {
 ubuntu-21.04() {
     STIME=$(date +%s)
     echo "$(date) Build redbpf with kernel headers on Ubuntu 21.04"
-    docker run --privileged -v $WORKDIR:/build -w /build $IMAGE_NAME:latest-ubuntu-21.04 /bin/bash -c 'cargo clean && export KERNEL_VERSION=$(ls --indicator-style=none /lib/modules/) && echo KERNEL_VERSION=$KERNEL_VERSION && cargo build && cargo build --examples --features=kernel5_8'
+    docker run --privileged -v $WORKDIR:/build -w /build $IMAGE_NAME:latest-ubuntu-21.04 /bin/bash -c 'cargo clean && export KERNEL_VERSION=$(ls --indicator-style=none /lib/modules/) && echo KERNEL_VERSION=$KERNEL_VERSION && cargo build && cargo build --examples --features=kernel5_9'
     ERR=$?
     ETIME=$(date +%s)
     echo "took $(((ETIME - STIME) / 60))m$(((ETIME - STIME) % 60))s"
@@ -51,7 +51,7 @@ ubuntu-21.04() {
 
     STIME=$(date +%s)
     echo "$(date) Build redbpf wih vmlinux on Ubuntu 21.04"
-    docker run --privileged -v $WORKDIR:/build -w /build $IMAGE_NAME:latest-ubuntu-21.04 /bin/bash -c 'cargo clean && /lib/modules/*/build/scripts/extract-vmlinux /boot/vmlinuz > /boot/vmlinux && export REDBPF_VMLINUX=/boot/vmlinux && cargo build && cargo build --examples --features=kernel5_8'
+    docker run --privileged -v $WORKDIR:/build -w /build $IMAGE_NAME:latest-ubuntu-21.04 /bin/bash -c 'cargo clean && /lib/modules/*/build/scripts/extract-vmlinux /boot/vmlinuz > /boot/vmlinux && export REDBPF_VMLINUX=/boot/vmlinux && cargo build && cargo build --examples --features=kernel5_9'
     ERR=$?
     ETIME=$(date +%s)
     echo "took $(((ETIME - STIME) / 60))m$(((ETIME - STIME) % 60))s"


### PR DESCRIPTION
If you haven't noticed already, there is a programming challenge going on and it looks like a few of us decided to tackle it with redbpf. Amazing technology, thank-you.

You might want to leave this for a few weeks and see whatever other sk_lookup PRs you get. You can pick the best one, or combine them or something. For example, I really like the more rustic bindings in https://github.com/foniod/redbpf/pull/228.
