### PR TITLE
Issue: zero crate has moved to 0.1.3 and build fails since then

### DIFF
--- a/bpf-sys/Cargo.toml
+++ b/bpf-sys/Cargo.toml
@@ -5,14 +5,17 @@ description = "Bindings for libbpf"
 repository = "https://github.com/foniod/redbpf"
 homepage = "https://foniod.org"
 documentation = "https://docs.rs/bpf-sys"
-authors = ["Peter Parkanyi <p@symmetree.dev>", "Junyeong Jeong <rhdxmr@gmail.com>"]
+authors = [
+    "Peter Parkanyi <p@symmetree.dev>",
+    "Junyeong Jeong <rhdxmr@gmail.com>",
+]
 links = "bpf"
 edition = "2018"
 license = "MIT OR Apache-2.0"
 keywords = ["bpf", "ebpf", "ffi"]
 
 [dependencies]
-zero = "0.1"
+zero = "0.1.2"
 libc = "0.2"
 regex = { version = "1.5" }
 glob = "0.3.0"
@@ -20,7 +23,9 @@ libbpf-sys = "0.6.2"
 
 [build-dependencies]
 cc = "1.0"
-bindgen = {version = "0.59.2", default-features = false, features = ["runtime"]}
+bindgen = { version = "0.59.2", default-features = false, features = [
+    "runtime",
+] }
 libc = "0.2"
 glob = "0.3.0"
 

--- a/redbpf/Cargo.toml
+++ b/redbpf/Cargo.toml
@@ -18,7 +18,7 @@ maintenance = { status = "actively-developed" }
 bpf-sys = { path = "../bpf-sys", version = "2.3.0" }
 libbpf-sys = "0.6.2"
 goblin = "0.4"
-zero = "0.1"
+zero = "0.1.2"
 libc = "0.2"
 bindgen = {version = "0.59.2", default-features = false, features = ["runtime"]}
 regex = "1.0"


### PR DESCRIPTION
- fixed Cargo.toml files to use version 0.1.2 instead of 0.1 (which would take latest version available).

Signed-off-by: Quentin JEROME <qjerome@users.noreply.github.com>