### PR TITLE
redbpf: compute symbol offset rather than address

### DIFF
--- a/redbpf/src/symbols.rs
+++ b/redbpf/src/symbols.rs
@@ -24,13 +24,12 @@ lazy_static! {
 const CACHE_HEADER: &str = "glibc-ld.so.cache1.1";
 
 pub(crate) struct ElfSymbols<'a> {
-    elf: Elf<'a>,
+    elf: &'a Elf<'a>,
 }
 
 impl<'a> ElfSymbols<'a> {
-    pub fn parse(data: &[u8]) -> goblin::error::Result<ElfSymbols> {
-        let elf = Elf::parse(&data)?;
-        Ok(ElfSymbols { elf })
+    pub fn new(elf: &'a Elf<'a>) -> ElfSymbols {
+        ElfSymbols { elf }
     }
 
     fn resolve_dyn_syms(&self, sym_name: &str) -> Option<Sym> {


### PR DESCRIPTION
Fixes #356 

BPF expects offsets in the object files rather than virtual memory addresses. In some cases, the virtual memory offset of the .text section is 0, in which case the correction in this change is a no-op. If the .text section has a non-zero address offset, the previous logic for determining the symbol offset was wrong.