### PR TITLE
update bindgen version to 0.66.1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -55,7 +55,7 @@ version = "0.59.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2bd2a9a458e8f4304c52c43ebb0cfbd520289f8379a52e329a38afda99bf8eb8"
 dependencies = [
- "bitflags",
+ "bitflags 1.3.2",
  "cexpr",
  "clang-sys",
  "lazy_static",
@@ -69,16 +69,42 @@ dependencies = [
 ]
 
 [[package]]
+name = "bindgen"
+version = "0.66.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f2b84e06fc203107bfbad243f4aba2af864eb7db3b1cf46ea0a023b0b433d2a7"
+dependencies = [
+ "bitflags 2.3.2",
+ "cexpr",
+ "clang-sys",
+ "lazy_static",
+ "lazycell",
+ "peeking_take_while",
+ "proc-macro2",
+ "quote",
+ "regex",
+ "rustc-hash",
+ "shlex",
+ "syn 2.0.22",
+]
+
+[[package]]
 name = "bitflags"
 version = "1.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
 
 [[package]]
+name = "bitflags"
+version = "2.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6dbe3c979c178231552ecba20214a8272df4e09f232a87aef4320cf06539aded"
+
+[[package]]
 name = "bpf-sys"
 version = "2.3.0"
 dependencies = [
- "bindgen",
+ "bindgen 0.66.1",
  "cc",
  "glob",
  "libbpf-sys",
@@ -110,7 +136,7 @@ name = "cargo-bpf"
 version = "2.3.0"
 dependencies = [
  "anyhow",
- "bindgen",
+ "bindgen 0.59.2",
  "bpf-sys",
  "cfg-if",
  "clap",
@@ -129,7 +155,7 @@ dependencies = [
  "rustc_version 0.4.0",
  "rustversion",
  "semver 1.0.7",
- "syn",
+ "syn 1.0.91",
  "tempfile",
  "tokio",
  "toml_edit",
@@ -188,7 +214,7 @@ checksum = "a0610544180c38b88101fecf2dd634b174a62eef6946f84dfc6a7127512b381c"
 dependencies = [
  "ansi_term",
  "atty",
- "bitflags",
+ "bitflags 1.3.2",
  "strsim",
  "textwrap",
  "unicode-width",
@@ -304,7 +330,7 @@ checksum = "33c1e13800337f4d4d7a316bf45a567dbcb6ffe087f16424852d97e97a91f512"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 1.0.91",
 ]
 
 [[package]]
@@ -647,18 +673,18 @@ checksum = "dbf0c48bc1d91375ae5c3cd81e3722dff1abcf81a30960240640d223f59fe0e5"
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.37"
+version = "1.0.63"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ec757218438d5fda206afc041538b2f6d889286160d649a86a24d37e1235afd1"
+checksum = "7b368fba921b0dce7e60f5e04ec15e565b3303972b42bcfde1d0713b881959eb"
 dependencies = [
- "unicode-xid",
+ "unicode-ident",
 ]
 
 [[package]]
 name = "quote"
-version = "1.0.17"
+version = "1.0.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "632d02bff7f874a36f33ea8bb416cd484b90cc66c1194b1a1110d067a7013f58"
+checksum = "1b9ab9c7eadfd8df19006f1cf1a4aed13540ed5cbc047010ece5826e10825488"
 dependencies = [
  "proc-macro2",
 ]
@@ -667,7 +693,7 @@ dependencies = [
 name = "redbpf"
 version = "2.3.0"
 dependencies = [
- "bindgen",
+ "bindgen 0.59.2",
  "bpf-sys",
  "byteorder",
  "futures",
@@ -693,7 +719,7 @@ dependencies = [
  "quote",
  "redbpf-probes",
  "rustc_version 0.3.3",
- "syn",
+ "syn 1.0.91",
  "uuid",
 ]
 
@@ -702,7 +728,7 @@ name = "redbpf-probes"
 version = "2.3.0"
 dependencies = [
  "anyhow",
- "bindgen",
+ "bindgen 0.59.2",
  "bpf-sys",
  "cargo-bpf",
  "cty",
@@ -711,7 +737,7 @@ dependencies = [
  "memoffset",
  "quote",
  "redbpf-macros",
- "syn",
+ "syn 1.0.91",
  "tracing",
  "tracing-subscriber 0.2.25",
  "ufmt",
@@ -736,7 +762,7 @@ version = "0.2.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "62f25bc4c7e55e0b0b7a1d43fb893f4fa1361d0abe38b9ce4f323c2adfe6ef42"
 dependencies = [
- "bitflags",
+ "bitflags 1.3.2",
 ]
 
 [[package]]
@@ -842,7 +868,7 @@ checksum = "aaaae8f38bb311444cfb7f1979af0bc9240d95795f75f9ceddf6a59b79ceffa0"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 1.0.91",
 ]
 
 [[package]]
@@ -883,7 +909,7 @@ checksum = "08597e7152fcd306f41838ed3e37be9eaeed2b61c42e2117266a554fab4662f9"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 1.0.91",
 ]
 
 [[package]]
@@ -967,6 +993,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "syn"
+version = "2.0.22"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2efbeae7acf4eabd6bcdcbd11c92f45231ddda7539edc7806bd1a04a03b24616"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "unicode-ident",
+]
+
+[[package]]
 name = "tempfile"
 version = "3.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1034,7 +1071,7 @@ checksum = "b557f72f448c511a979e2564e55d74e6c4432fc96ff4f6241bc6bded342643b7"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 1.0.91",
 ]
 
 [[package]]
@@ -1068,7 +1105,7 @@ checksum = "2e65ce065b4b5c53e73bb28912318cb8c9e9ad3921f1d669eb0e68b4c8143a2b"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 1.0.91",
 ]
 
 [[package]]
@@ -1164,7 +1201,7 @@ dependencies = [
  "proc-macro-hack",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 1.0.91",
 ]
 
 [[package]]
@@ -1172,6 +1209,12 @@ name = "ufmt-write"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e87a2ed6b42ec5e28cc3b94c09982969e9227600b2e3dcbc1db927a84c06bd69"
+
+[[package]]
+name = "unicode-ident"
+version = "1.0.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b15811caf2415fb889178633e7724bad2509101cde276048e013b9def5e51fa0"
 
 [[package]]
 name = "unicode-width"
@@ -1245,7 +1288,7 @@ dependencies = [
  "log",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 1.0.91",
  "wasm-bindgen-shared",
 ]
 
@@ -1267,7 +1310,7 @@ checksum = "bfa8a30d46208db204854cadbb5d4baf5fcf8071ba5bf48190c3e59937962ebc"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 1.0.91",
  "wasm-bindgen-backend",
  "wasm-bindgen-shared",
 ]

--- a/bpf-sys/Cargo.toml
+++ b/bpf-sys/Cargo.toml
@@ -20,7 +20,7 @@ libbpf-sys = "0.6.2"
 
 [build-dependencies]
 cc = "1.0"
-bindgen = {version = "0.59.2", default-features = false, features = ["runtime"]}
+bindgen = {version = "0.66.1", default-features = false, features = ["runtime"]}
 libc = "0.2"
 glob = "0.3.0"
 

--- a/cargo-bpf/Cargo.toml
+++ b/cargo-bpf/Cargo.toml
@@ -20,7 +20,7 @@ required-features = ["command-line"]
 
 [dependencies]
 clap = { version = "2.33", optional = true }
-bindgen = {version = "0.59.2", default-features = false, features = ["runtime"], optional = true}
+bindgen = {version = "0.66.1", default-features = false, features = ["runtime"], optional = true}
 toml_edit = { version = "0.2", optional = true }
 libbpf-sys = { version = "0.6.2", optional = true }
 bpf-sys = { version = "2.3.0", path = "../bpf-sys", optional = true }

--- a/redbpf-probes/Cargo.toml
+++ b/redbpf-probes/Cargo.toml
@@ -22,7 +22,7 @@ libbpf-sys = "0.6.2"
 syn = {version = "1.0", default-features = false, features = ["parsing", "visit"] }
 quote = "1.0"
 glob = "0.3.0"
-bindgen = { version = "0.59.2", default-features = false, features = ["runtime"] }
+bindgen = { version = "0.66.1", default-features = false, features = ["runtime"] }
 anyhow = "1.0"
 tracing = "0.1.26"
 tracing-subscriber = "0.2.18"


### PR DESCRIPTION
When I tried to build the bpf-sys on my arm64 machine, I got an error ([detail](https://github.com/rust-lang/rust-bindgen/issues/2568)). I solved the problem by updating the bindgen version. 